### PR TITLE
fix: update validation regex and related test API key

### DIFF
--- a/Kontent.Ai.Delivery.Tests/Builders/Configuration/DeliveryOptionsBuilderTests.cs
+++ b/Kontent.Ai.Delivery.Tests/Builders/Configuration/DeliveryOptionsBuilderTests.cs
@@ -9,8 +9,8 @@ namespace Kontent.Ai.Delivery.Tests.Builders.Configuration
     {
         private const string ProjectId = "550cec62-90a6-4ab3-b3e4-3d0bb4c04f5c";
         private const string PreviewApiKey = 
-            "eyJ0eXAiOiwq14X65DLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiABCjJlM2FiOTBjOGM0ODVmYjdmZTDEFRQZGM1NDIyMCIsImlhdCI6IjE1Mjg454wexiLCJleHAiOiIxODc0NDg3NjqasdfwicHJvamVjdF9pZCI6Ij" +
-            "g1OTEwOTlkN2458198ewqewZjI3Yzg5M2FhZTJiNTE4IiwidmVyIjoiMS4wLjAiLCJhdWQiewqgsdaWV3LmRlbGl2ZXIua2VudGljb2Nsb3VkLmNvbSJ9.wtSzbNDpbE55dsaLUTGsdgesg4b693TFuhRCRsDyoc";
+            "eyJ0eXAiOiwq14X65DLCJhbGciOiJIUzI1NiJ-.eyJqdGkiOiABCjJlM2FiOTBjOGM0ODVmYjdmZTDEFRQZGM1NDIyMCIsImlhdCI6IjE1Mjg454wexiLCJleHAiOiIxODc0NDg3NjqasdfwicHJvamVjdF9pZCI6Ij" +
+            "g1OTEwOTlkN2458198ewqewZjI3Yzg5M2FhZTJiNTE4IiwidmVyIjoiMS4wLjAiLCJhdWQiewqgsdaWV3LmRlbGl2ZXIua2VudGljb2Nsb3VkLmNvbSJ9._tSzbNDpbE55dsaLUTGsdgesg4b693TFuhRCRsDyoc";
 
         private const string SecuredApiKey =
             "eyJ0eXAiOiwq14X65DLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiABCjJlM2FiOTBjOGM0ODVmYjdmZTDEFRQZGM1ND123QEwclhdCI6IjE1Mjg454wexiLCJleHAiOiIxODc0NDg3NjqasdfwicHJvamVjdF9pZCI6Ij" +

--- a/Kontent.Ai.Delivery/Configuration/DeliveryOptionsValidator.cs
+++ b/Kontent.Ai.Delivery/Configuration/DeliveryOptionsValidator.cs
@@ -9,7 +9,7 @@ namespace Kontent.Ai.Delivery.Configuration
     /// </summary>
     public static class DeliveryOptionsValidator
     {
-        internal static Lazy<Regex> ApiKeyRegex = new Lazy<Regex>(() => new Regex(@"[A-Za-z0-9-_+/]+\.[A-Za-z0-9-_+/]+\.[A-Za-z0-9-_+/]+", RegexOptions.Compiled));
+        internal static Lazy<Regex> ApiKeyRegex = new Lazy<Regex>(() => new Regex(@"[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+", RegexOptions.Compiled));
 
         /// <summary>
         /// Validates an instance of the <see cref="DeliveryOptions"/> class if it is compatible with <see cref="DeliveryClient"/>.

--- a/Kontent.Ai.Delivery/Configuration/DeliveryOptionsValidator.cs
+++ b/Kontent.Ai.Delivery/Configuration/DeliveryOptionsValidator.cs
@@ -9,7 +9,7 @@ namespace Kontent.Ai.Delivery.Configuration
     /// </summary>
     public static class DeliveryOptionsValidator
     {
-        internal static Lazy<Regex> ApiKeyRegex = new Lazy<Regex>(() => new Regex(@"[A-Za-z0-9+/]+\.[A-Za-z0-9+/]+\.[A-Za-z0-9+/]+", RegexOptions.Compiled));
+        internal static Lazy<Regex> ApiKeyRegex = new Lazy<Regex>(() => new Regex(@"[A-Za-z0-9-_+/]+\.[A-Za-z0-9-_+/]+\.[A-Za-z0-9-_+/]+", RegexOptions.Compiled));
 
         /// <summary>
         /// Validates an instance of the <see cref="DeliveryOptions"/> class if it is compatible with <see cref="DeliveryClient"/>.


### PR DESCRIPTION
### Motivation

Fixes #348

Test API key was updated manually, may not be a valid JWT but does illustrate the problem. Can provide a valid key that originally caused the issue in question.
