### PR TITLE
Add DisplayTimezone converter atttribute

### DIFF
--- a/Kontent.Ai.Delivery.Abstractions/DisplayTimzoneConverterAttribute.cs
+++ b/Kontent.Ai.Delivery.Abstractions/DisplayTimzoneConverterAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Kontent.Ai.Delivery.Abstractions;
+
+namespace Kontent.Ai.Delivery.Abstractions
+{
+    /// <summary>
+    /// Specifies property of a model to map DisplayTimezone value into
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DisplayTimzoneConverterAttribute : Attribute, IPropertyValueConverter<DateTime>
+    {
+        Task<object> IPropertyValueConverter<DateTime>.GetPropertyValueAsync<TElement>(PropertyInfo property, TElement element, ResolvingContext context)
+        {
+            if (element is not IDateTimeElementValue dateTimeElement)
+            {
+                return null;
+            }
+
+            return Task.FromResult<object>(dateTimeElement.DisplayTimezone);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation - sanity check review

Implementing DateTimeElement DisplayTimezone support through a `DisplayTimzoneConverterAttribute` that can be used to decorate fields in DAPI models. Related to changes in [model generators PR](https://github.com/kontent-ai/model-generator-net/pull/166).

Inspiration taken from PropertyValueConverters in SDK tests. Implemented converter that maps TZ value from DateTime element into a property in model that is decorated with target element codename and the converter attribute. 

I can add more context on demand in person

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Check that:
- Old models that don't access the timezone work with updated version
- Check that TZ maps correctly for newly generated models from updated PR with correct attributes 
