### PR TITLE
Add support for exclude parameter

### DIFF
--- a/Kontent.Ai.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kontent.Ai.Delivery.Tests/DeliveryClientTests.cs
@@ -733,7 +733,7 @@ namespace Kontent.Ai.Delivery.Tests
         public async Task QueryParameters()
         {
             _mockHttp.Expect($"{_baseUrl}/items")
-                .WithExactQueryString("elements.personas%5Ball%5D=barista%2Ccoffee%2Cblogger&elements.personas%5Bany%5D=barista%2Ccoffee%2Cblogger&system.sitemap_locations%5Bcontains%5D=cafes&elements.product_name%5Beq%5D=Hario%20V60&elements.product_name%5Bneq%5D=Hario%20V42&elements.price%5Bgt%5D=1000&elements.price%5Bgte%5D=50&system.type%5Bin%5D=cafe%2Ccoffee&system.type%5Bnin%5D=article%2Cblog_post&elements.price%5Blt%5D=10&elements.price%5Blte%5D=4&elements.country%5Brange%5D=Guatemala%2CNicaragua&elements.price%5Bempty%5D&elements.country%5Bnempty%5D&depth=2&elements=price%2Cproduct_name&exclude=product_description%2Cproduct_thumbnail&limit=10&order=elements.price%5Bdesc%5D&skip=2&language=en&includeTotalCount")
+                .WithExactQueryString("elements.personas%5Ball%5D=barista%2Ccoffee%2Cblogger&elements.personas%5Bany%5D=barista%2Ccoffee%2Cblogger&system.sitemap_locations%5Bcontains%5D=cafes&elements.product_name%5Beq%5D=Hario%20V60&elements.product_name%5Bneq%5D=Hario%20V42&elements.price%5Bgt%5D=1000&elements.price%5Bgte%5D=50&system.type%5Bin%5D=cafe%2Ccoffee&system.type%5Bnin%5D=article%2Cblog_post&elements.price%5Blt%5D=10&elements.price%5Blte%5D=4&elements.country%5Brange%5D=Guatemala%2CNicaragua&elements.price%5Bempty%5D&elements.country%5Bnempty%5D&depth=2&elements=price%2Cproduct_name&excludeElements=product_description%2Cproduct_thumbnail&limit=10&order=elements.price%5Bdesc%5D&skip=2&language=en&includeTotalCount")
                 .Respond("application/json", " { 'items': [],'modular_content': {},'pagination': {'skip': 2,'limit': 10,'count': 0, 'total_count': 0, 'next_page': ''}}");
 
             var client = InitializeDeliveryClientWithACustomTypeProvider(_mockHttp);
@@ -756,7 +756,7 @@ namespace Kontent.Ai.Delivery.Tests
                 new NotEmptyFilter("elements.country"),
                 new DepthParameter(2),
                 new ElementsParameter("price", "product_name"),
-                new ExcludeParameter("product_description", "product_thumbnail"),
+                new ExcludeElementsParameter("product_description", "product_thumbnail"),
                 new LimitParameter(10),
                 new OrderParameter("elements.price", SortOrder.Descending),
                 new SkipParameter(2),

--- a/Kontent.Ai.Delivery.Tests/DeliveryClientTests.cs
+++ b/Kontent.Ai.Delivery.Tests/DeliveryClientTests.cs
@@ -732,9 +732,8 @@ namespace Kontent.Ai.Delivery.Tests
         [Fact]
         public async Task QueryParameters()
         {
-            string url = $"{_baseUrl}/items?elements.personas%5Ball%5D=barista%2Ccoffee%2Cblogger&elements.personas%5Bany%5D=barista%2Ccoffee%2Cblogger&system.sitemap_locations%5Bcontains%5D=cafes&elements.product_name%5Beq%5D=Hario%20V60&elements.product_name%5Bneq%5D=Hario%20V42&elements.price%5Bgt%5D=1000&elements.price%5Bgte%5D=50&system.type%5Bin%5D=cafe%2Ccoffee&system.type%5Bnin%5D=article%2Cblog_post&elements.price%5Blt%5D=10&elements.price%5Blte%5D=4&elements.country%5Brange%5D=Guatemala%2CNicaragua&elements.price%5Bempty%5D&elements.country%5Bnempty%5D&depth=2&elements=price%2Cproduct_name&limit=10&order=elements.price%5Bdesc%5D&skip=2&language=en&includeTotalCount";
-            _mockHttp
-                .When($"{url}")
+            _mockHttp.Expect($"{_baseUrl}/items")
+                .WithExactQueryString("elements.personas%5Ball%5D=barista%2Ccoffee%2Cblogger&elements.personas%5Bany%5D=barista%2Ccoffee%2Cblogger&system.sitemap_locations%5Bcontains%5D=cafes&elements.product_name%5Beq%5D=Hario%20V60&elements.product_name%5Bneq%5D=Hario%20V42&elements.price%5Bgt%5D=1000&elements.price%5Bgte%5D=50&system.type%5Bin%5D=cafe%2Ccoffee&system.type%5Bnin%5D=article%2Cblog_post&elements.price%5Blt%5D=10&elements.price%5Blte%5D=4&elements.country%5Brange%5D=Guatemala%2CNicaragua&elements.price%5Bempty%5D&elements.country%5Bnempty%5D&depth=2&elements=price%2Cproduct_name&exclude=product_description%2Cproduct_thumbnail&limit=10&order=elements.price%5Bdesc%5D&skip=2&language=en&includeTotalCount")
                 .Respond("application/json", " { 'items': [],'modular_content': {},'pagination': {'skip': 2,'limit': 10,'count': 0, 'total_count': 0, 'next_page': ''}}");
 
             var client = InitializeDeliveryClientWithACustomTypeProvider(_mockHttp);
@@ -757,6 +756,7 @@ namespace Kontent.Ai.Delivery.Tests
                 new NotEmptyFilter("elements.country"),
                 new DepthParameter(2),
                 new ElementsParameter("price", "product_name"),
+                new ExcludeParameter("product_description", "product_thumbnail"),
                 new LimitParameter(10),
                 new OrderParameter("elements.price", SortOrder.Descending),
                 new SkipParameter(2),

--- a/Kontent.Ai.Urls/Delivery/QueryParameters/ExcludeElementsParameter.cs
+++ b/Kontent.Ai.Urls/Delivery/QueryParameters/ExcludeElementsParameter.cs
@@ -8,7 +8,7 @@ namespace Kontent.Ai.Urls.Delivery.QueryParameters
     /// <summary>
     /// Specifies the content elements to exclude from response.
     /// </summary>
-    public sealed class ExcludeParameter : IQueryParameter
+    public sealed class ExcludeElementsParameter : IQueryParameter
     {
         /// <summary>
         /// Gets the list of codenames of content elements that should be excluded from response.
@@ -16,10 +16,10 @@ namespace Kontent.Ai.Urls.Delivery.QueryParameters
         public IReadOnlyList<string> ElementCodenames { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ExcludeParameter"/> class using the specified content elements codenames.
+        /// Initializes a new instance of the <see cref="ExcludeElementsParameter"/> class using the specified content elements codenames.
         /// </summary>
         /// <param name="elementCodenames">An array that contains zero or more codenames of the content elements that should be excluded from response.</param>
-        public ExcludeParameter(params string[] elementCodenames)
+        public ExcludeElementsParameter(params string[] elementCodenames)
         {
             ElementCodenames = elementCodenames.ToList().AsReadOnly();
         }
@@ -29,7 +29,7 @@ namespace Kontent.Ai.Urls.Delivery.QueryParameters
         /// </summary>
         public string GetQueryStringParameter()
         {
-            return $"exclude={string.Join(Uri.EscapeDataString(","), ElementCodenames.Select(Uri.EscapeDataString))}";
+            return $"excludeElements={string.Join(Uri.EscapeDataString(","), ElementCodenames.Select(Uri.EscapeDataString))}";
         }
     }
 }

--- a/Kontent.Ai.Urls/Delivery/QueryParameters/ExcludeParameter.cs
+++ b/Kontent.Ai.Urls/Delivery/QueryParameters/ExcludeParameter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Kontent.Ai.Delivery.Abstractions;
+
+namespace Kontent.Ai.Urls.Delivery.QueryParameters
+{
+    /// <summary>
+    /// Specifies the content elements to exclude from response.
+    /// </summary>
+    public sealed class ExcludeParameter : IQueryParameter
+    {
+        /// <summary>
+        /// Gets the list of codenames of content elements that should be excluded from response.
+        /// </summary>
+        public IReadOnlyList<string> ElementCodenames { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExcludeParameter"/> class using the specified content elements codenames.
+        /// </summary>
+        /// <param name="elementCodenames">An array that contains zero or more codenames of the content elements that should be excluded from response.</param>
+        public ExcludeParameter(params string[] elementCodenames)
+        {
+            ElementCodenames = elementCodenames.ToList().AsReadOnly();
+        }
+
+        /// <summary>
+        /// Returns the query string representation of the query parameter.
+        /// </summary>
+        public string GetQueryStringParameter()
+        {
+            return $"exclude={string.Join(Uri.EscapeDataString(","), ElementCodenames.Select(Uri.EscapeDataString))}";
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Add support for new exclude query string parameter, that allows user to specify codenames of elements that should be excluded from API response.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test


