### PR TITLE
Package vulnerability updates

### DIFF
--- a/Kontent.Ai.Delivery.Abstractions.Tests/Kontent.Ai.Delivery.Abstractions.Tests.csproj
+++ b/Kontent.Ai.Delivery.Abstractions.Tests/Kontent.Ai.Delivery.Abstractions.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Kontent.Ai.Delivery.Benchmarks/Kontent.Ai.Delivery.Benchmarks.csproj
+++ b/Kontent.Ai.Delivery.Benchmarks/Kontent.Ai.Delivery.Benchmarks.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Kontent.Ai.Delivery.Caching.Tests/BinarySerializationTests.cs
+++ b/Kontent.Ai.Delivery.Caching.Tests/BinarySerializationTests.cs
@@ -8,6 +8,7 @@ using Kontent.Ai.Delivery.ContentItems;
 using RichardSzalay.MockHttp;
 using FluentAssertions;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace Kontent.Ai.Delivery.Caching.Tests
 {
@@ -26,7 +27,7 @@ namespace Kontent.Ai.Delivery.Caching.Tests
         }
 
         [Fact]
-        public async void GetItemAsync_SerializeAndDeserialize()
+        public async Task GetItemAsync_SerializeAndDeserialize()
         {
             // Arrange
             string url = $"{_baseUrl}/items/brazil_natural_barra_grande";
@@ -51,7 +52,7 @@ namespace Kontent.Ai.Delivery.Caching.Tests
         }
 
         [Fact]
-        public async void GetItemsAsync_SerializeAndDeserialize()
+        public async Task GetItemsAsync_SerializeAndDeserialize()
         {
             // Arrange
             string url = $"{_baseUrl}/items";

--- a/Kontent.Ai.Delivery.Caching.Tests/CacheHelpersTests.cs
+++ b/Kontent.Ai.Delivery.Caching.Tests/CacheHelpersTests.cs
@@ -120,12 +120,16 @@ namespace Kontent.Ai.Delivery.Caching.Tests
     }
 
     internal class SomeClass { }
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
     internal class someclass { }
+#pragma warning restore CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
 }
 
 namespace Kontent.Ai.Delivery.Caching.Tests.AnotherNamespace
 {
     internal class SomeClass { }
+#pragma warning disable CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
     internal class someclass { }
+#pragma warning restore CS8981 // The type name only contains lower-cased ascii characters. Such names may become reserved for the language.
 }
 

--- a/Kontent.Ai.Delivery.Caching.Tests/Kontent.Ai.Delivery.Caching.Tests.csproj
+++ b/Kontent.Ai.Delivery.Caching.Tests/Kontent.Ai.Delivery.Caching.Tests.csproj
@@ -9,10 +9,12 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Kontent.Ai.Delivery.Caching/Kontent.Ai.Delivery.Caching.csproj
+++ b/Kontent.Ai.Delivery.Caching/Kontent.Ai.Delivery.Caching.csproj
@@ -24,15 +24,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
-    <PackageReference Include="Scrutor" Version="4.2.0" />
-    <None Include="../README.md" Pack="true" PackagePath=""/>
-    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath=""/>
+    <PackageReference Include="Scrutor" Version="5.0.2" />
+    <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kontent.Ai.Delivery.Extensions.DependencyInjection.Tests/Kontent.Ai.Delivery.Extensions.DependencyInjection.Tests.csproj
+++ b/Kontent.Ai.Delivery.Extensions.DependencyInjection.Tests/Kontent.Ai.Delivery.Extensions.DependencyInjection.Tests.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Kontent.Ai.Delivery.Extensions.DependencyInjection/Kontent.Ai.Delivery.Extensions.DependencyInjection.csproj
+++ b/Kontent.Ai.Delivery.Extensions.DependencyInjection/Kontent.Ai.Delivery.Extensions.DependencyInjection.csproj
@@ -30,11 +30,11 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <None Include="../README.md" Pack="true" PackagePath=""/>
-    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath=""/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kontent.Ai.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
+++ b/Kontent.Ai.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
@@ -33,7 +33,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
         }
 
         [Fact]
-        public async void TypedItemRetrieved()
+        public async Task TypedItemRetrieved()
         {
             var observable = new DeliveryObservableProxy(GetDeliveryClient(MockItem)).GetItemObservable<Article>(BEVERAGES_IDENTIFIER, new LanguageParameter("es-ES"));
             var item = await observable.FirstOrDefaultAsync();
@@ -43,7 +43,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
         }
 
         [Fact]
-        public async void RuntimeTypedItemRetrieved()
+        public async Task RuntimeTypedItemRetrieved()
         {
             var observable = new DeliveryObservableProxy(GetDeliveryClient(MockItem)).GetItemObservable<object>(BEVERAGES_IDENTIFIER, new LanguageParameter("es-ES"));
             var item = await observable.FirstOrDefaultAsync();
@@ -98,7 +98,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
         }
 
         [Fact]
-        public async void TypeRetrieved()
+        public async Task TypeRetrieved()
         {
             var observable = new DeliveryObservableProxy(GetDeliveryClient(MockType)).GetTypeObservable(Article.Codename);
             var type = await observable.FirstOrDefaultAsync();
@@ -120,7 +120,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
         }
 
         [Fact]
-        public async void ElementRetrieved()
+        public async Task ElementRetrieved()
         {
             var observable = new DeliveryObservableProxy(GetDeliveryClient(MockElement)).GetElementObservable(Article.Codename, Article.TitleCodename);
             var element = await observable.FirstOrDefaultAsync();
@@ -132,7 +132,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
         }
 
         [Fact]
-        public async void TaxonomyElementRetrieved()
+        public async Task TaxonomyElementRetrieved()
         {
             var observable = new DeliveryObservableProxy(GetDeliveryClient(MockTaxonomyElement)).GetElementObservable(Coffee.Codename, Coffee.ProcessingCodename);
             var element = await observable.FirstOrDefaultAsync();
@@ -141,7 +141,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
         }
 
         [Fact]
-        public async void MultipleChoiceElementRetrieved()
+        public async Task MultipleChoiceElementRetrieved()
         {
             var observable = new DeliveryObservableProxy(GetDeliveryClient(MockMultipleChoiceElement)).GetElementObservable(Tweet.Codename, Tweet.ThemeCodename);
             var element = await observable.FirstOrDefaultAsync();
@@ -150,7 +150,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
         }
 
         [Fact]
-        public async void TaxonomyRetrieved()
+        public async Task TaxonomyRetrieved()
         {
             var observable = new DeliveryObservableProxy(GetDeliveryClient(MockTaxonomy)).GetTaxonomyObservable("personas");
             var taxonomy = await observable.FirstOrDefaultAsync();

--- a/Kontent.Ai.Delivery.Rx.Tests/Kontent.Ai.Delivery.Rx.Tests.csproj
+++ b/Kontent.Ai.Delivery.Rx.Tests/Kontent.Ai.Delivery.Rx.Tests.csproj
@@ -45,10 +45,10 @@
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Kontent.Ai.Delivery.Tests/ContentLinkResolverTests.cs
+++ b/Kontent.Ai.Delivery.Tests/ContentLinkResolverTests.cs
@@ -120,7 +120,7 @@ namespace Kontent.Ai.Delivery.Tests
         }
 
         [Fact]
-        public async void ResolveLinksInStronglyTypedModel()
+        public async Task ResolveLinksInStronglyTypedModel()
         {
             var mockHttp = new MockHttpMessageHandler();
             string guid = Guid.NewGuid().ToString();

--- a/Kontent.Ai.Delivery.Tests/FakeHttpClientTests.cs
+++ b/Kontent.Ai.Delivery.Tests/FakeHttpClientTests.cs
@@ -18,7 +18,7 @@ namespace Kontent.Ai.Delivery.Tests
     public class FakeHttpClientTests
     {
         [Fact]
-        public async void GetItemAsync()
+        public async Task GetItemAsync()
         {
             // Arrange
             const string testUrl = "https://tests.fake.url";

--- a/Kontent.Ai.Delivery.Tests/Kontent.Ai.Delivery.Tests.csproj
+++ b/Kontent.Ai.Delivery.Tests/Kontent.Ai.Delivery.Tests.csproj
@@ -29,19 +29,22 @@
     <PackageReference Include="Castle.Windsor" Version="6.0.0" />
     <PackageReference Include="Castle.Windsor.MsDependencyInjection" Version="4.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="NodaTime" Version="3.1.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="SimpleInjector" Version="5.4.0" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore" Version="5.4.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Unity" Version="5.11.10" />
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Kontent.Ai.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
+++ b/Kontent.Ai.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FakeItEasy;
 using FluentAssertions;
 using Kontent.Ai.Delivery.Abstractions;
@@ -59,7 +60,7 @@ namespace Kontent.Ai.Delivery.Tests.QueryParameters
         }
 
         [Fact]
-        public async void GetItems_DeliveryOptionsWithIncludeTotalCount_IncludeTotalCountParameterAdded()
+        public async Task GetItems_DeliveryOptionsWithIncludeTotalCount_IncludeTotalCountParameterAdded()
         {
             var responseJson = JsonConvert.SerializeObject(CreateItemsResponse());
             _mockHttp
@@ -74,7 +75,7 @@ namespace Kontent.Ai.Delivery.Tests.QueryParameters
         }
 
         [Fact]
-        public async void GetItemsTyped_DeliveryOptionsWithIncludeTotalCount_IncludeTotalCountParameterAdded()
+        public async Task GetItemsTyped_DeliveryOptionsWithIncludeTotalCount_IncludeTotalCountParameterAdded()
         {
             var responseJson = JsonConvert.SerializeObject(CreateItemsResponse());
             _mockHttp

--- a/Kontent.Ai.Delivery.Tests/ValueConverterTests.cs
+++ b/Kontent.Ai.Delivery.Tests/ValueConverterTests.cs
@@ -63,7 +63,7 @@ namespace Kontent.Ai.Delivery.Tests
         }
 
         [Fact]
-        public async void LinkedItemCodenamesValueConverter()
+        public async Task LinkedItemCodenamesValueConverter()
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When($"{_baseUrl}/items/on_roasts")
@@ -76,7 +76,7 @@ namespace Kontent.Ai.Delivery.Tests
         }
 
         [Fact]
-        public async void GreeterPropertyValueConverter()
+        public async Task GreeterPropertyValueConverter()
         {
             var mockHttp = new MockHttpMessageHandler();
             string url = $"{_baseUrl}/items/on_roasts";
@@ -90,7 +90,7 @@ namespace Kontent.Ai.Delivery.Tests
         }
 
         [Fact]
-        public async void NodaTimePropertyValueConverter()
+        public async Task NodaTimePropertyValueConverter()
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When($"{_baseUrl}/items/on_roasts")
@@ -103,7 +103,7 @@ namespace Kontent.Ai.Delivery.Tests
         }
 
         [Fact]
-        public async void RichTextViaValueConverter()
+        public async Task RichTextViaValueConverter()
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When($"{_baseUrl}/items/coffee_beverages_explained")

--- a/Kontent.Ai.Delivery/Kontent.Ai.Delivery.csproj
+++ b/Kontent.Ai.Delivery/Kontent.Ai.Delivery.csproj
@@ -25,18 +25,18 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.17.1" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Scrutor" Version="4.2.0" />
+    <PackageReference Include="Scrutor" Version="5.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Sourcelink.Github" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <None Include="../README.md" Pack="true" PackagePath="" />
     <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/Kontent.Ai.Urls.Tests/Kontent.Ai.Urls.Tests.csproj
+++ b/Kontent.Ai.Urls.Tests/Kontent.Ai.Urls.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Kontent.Ai.Urls/Kontent.Ai.Urls.csproj
+++ b/Kontent.Ai.Urls/Kontent.Ai.Urls.csproj
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <None Include="../README.md" Pack="true" PackagePath=""/>
-    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath=""/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #399 

NOTES: 
1. AutoFixture does not have a new release available that updates some of it's transitive dependencies with vulnerabilities so those were updated by pinning the newer version of the assembly in those projects that used that Autofixture nuget package.
2. xunit had dependencies that were marked as vulnerable so that was updated as well. This also involved changing "async void" to "async Task" as the "async void" methods were showing xunit deprecation notices.
3. CS8981 pragma warning added to remove that noise from the build output
4. Since this package now targets .net 8 and above, removed most of the older .net core 6 references to their .net 8 counterparts

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Ran all automated tests, manual testing would probably be good as well however.
