### PR TITLE
Add support for used in endpoints

### DIFF
--- a/Kontent.Ai.Delivery.Abstractions/DeliveryClientExtensions.cs
+++ b/Kontent.Ai.Delivery.Abstractions/DeliveryClientExtensions.cs
@@ -94,7 +94,7 @@ namespace Kontent.Ai.Delivery.Abstractions
         /// </summary>
         /// <param name="client">An instance of the <see cref="IDeliveryClient"/></param>
         /// <param name="codename">The codename of a content item.</param>
-        /// <param name="parameters">An array that contains zero or more query parameters, for example, for filtering or ordering.</param>
+        /// <param name="parameters">An array that contains zero or more query parameters for filtering.</param>
         /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public static IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(this IDeliveryClient client, string codename, params IQueryParameter[] parameters)
         {
@@ -106,7 +106,7 @@ namespace Kontent.Ai.Delivery.Abstractions
         /// </summary>
         /// <param name="client">An instance of the <see cref="IDeliveryClient"/></param>
         /// <param name="codename">The codename of an asset.</param>
-        /// <param name="parameters">An array that contains zero or more query parameters, for example, for filtering, or ordering.</param>
+        /// <param name="parameters">An array that contains zero or more query parameters for filtering.</param>
         /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public static IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(this IDeliveryClient client, string codename, params IQueryParameter[] parameters)
         {

--- a/Kontent.Ai.Delivery.Abstractions/DeliveryClientExtensions.cs
+++ b/Kontent.Ai.Delivery.Abstractions/DeliveryClientExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Kontent.Ai.Delivery.Abstractions
 {
@@ -86,6 +87,30 @@ namespace Kontent.Ai.Delivery.Abstractions
         public static Task<IDeliverySyncInitResponse> PostSyncInitAsync(this IDeliveryClient client, params IQueryParameter[] parameters)
         {
             return client.PostSyncInitAsync(parameters);
+        }
+
+        /// <summary>
+        /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
+        /// </summary>
+        /// <param name="client">An instance of the <see cref="IDeliveryClient"/></param>
+        /// <param name="codename">The codename of a content item.</param>
+        /// <param name="parameters">An array that contains zero or more query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
+        public static IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(this IDeliveryClient client, string codename, params IQueryParameter[] parameters)
+        {
+            return client.GetItemUsedIn(codename, parameters);
+        }
+
+        /// <summary>
+        /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
+        /// </summary>
+        /// <param name="client">An instance of the <see cref="IDeliveryClient"/></param>
+        /// <param name="codename">The codename of an asset.</param>
+        /// <param name="parameters">An array that contains zero or more query parameters, for example, for filtering, or ordering.</param>
+        /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
+        public static IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(this IDeliveryClient client, string codename, params IQueryParameter[] parameters)
+        {
+            return client.GetAssetUsedIn(codename, parameters);
         }
     }
 }

--- a/Kontent.Ai.Delivery.Abstractions/IDeliveryClient.cs
+++ b/Kontent.Ai.Delivery.Abstractions/IDeliveryClient.cs
@@ -94,7 +94,7 @@ namespace Kontent.Ai.Delivery.Abstractions
         /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
         /// </summary>
         /// <param name="codename">The codename of a content item.</param>
-        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <param name="parameters">A collection of query parameters for filtering.</param>
         /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null);
 
@@ -102,7 +102,7 @@ namespace Kontent.Ai.Delivery.Abstractions
         /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
         /// </summary>
         /// <param name="codename">The codename of an asset.</param>
-        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <param name="parameters">A collection of query parameters for filtering.</param>
         /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null);
     }

--- a/Kontent.Ai.Delivery.Abstractions/IDeliveryClient.cs
+++ b/Kontent.Ai.Delivery.Abstractions/IDeliveryClient.cs
@@ -89,5 +89,21 @@ namespace Kontent.Ai.Delivery.Abstractions
         /// </summary>
         /// <returns>The <see cref="IDeliverySyncResponse"/> instance that represents the sync response that contains collection of delta updates and continuation token needed for further sync execution.</returns>
         Task<IDeliverySyncResponse> GetSyncAsync(string continuationToken);
+
+        /// <summary>
+        /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
+        /// </summary>
+        /// <param name="codename">The codename of a content item.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
+        public IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null);
+
+        /// <summary>
+        /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
+        /// </summary>
+        /// <param name="codename">The codename of an asset.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
+        public IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null);
     }
 }

--- a/Kontent.Ai.Delivery.Abstractions/UsedIn/IUsedInItem.cs
+++ b/Kontent.Ai.Delivery.Abstractions/UsedIn/IUsedInItem.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Kontent.Ai.Delivery.Abstractions;
+
+/// <summary>
+/// Represents a parent content item.
+/// </summary>
+public interface IUsedInItem
+{
+    /// <summary>
+    /// Represents system attributes of a parent content item.
+    /// </summary>
+    public IUsedInItemSystemAttributes System { get; }
+}

--- a/Kontent.Ai.Delivery.Abstractions/UsedIn/IUsedInItemSystemAttributes.cs
+++ b/Kontent.Ai.Delivery.Abstractions/UsedIn/IUsedInItemSystemAttributes.cs
@@ -1,0 +1,33 @@
+﻿namespace Kontent.Ai.Delivery.Abstractions
+{
+    /// <summary>
+    /// Represents system attributes of a parent content item.
+    /// </summary>
+    public interface IUsedInItemSystemAttributes : ISystemAttributes
+    {
+        /// <summary>
+        /// Gets the language of the content item.
+        /// </summary>
+        string Language { get; }
+
+        /// <summary>
+        /// Gets the codename of the content type, for example "article".
+        /// </summary>
+        string Type { get; }
+
+        /// <summary>
+        /// Gets the codename of the content collection to which the content item belongs.
+        /// </summary>
+        public string Collection { get; }
+
+        /// <summary>
+        /// Gets the codename of the workflow which the content item is assigned to.
+        /// </summary>
+        public string Workflow { get; }
+
+        /// <summary>
+        /// Gets the codename of the workflow step which the content item is assigned to.
+        /// </summary>
+        public string WorkflowStep { get; }
+    }
+}

--- a/Kontent.Ai.Delivery.Caching/DeliveryClientCache.cs
+++ b/Kontent.Ai.Delivery.Caching/DeliveryClientCache.cs
@@ -175,5 +175,27 @@ namespace Kontent.Ai.Delivery.Caching
         {
             return _deliveryClient.GetSyncAsync(continuationToken);
         }
+
+        /// <summary>
+        /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
+        /// </summary>
+        /// <param name="codename">The codename of a content item.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
+        public IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
+        {
+            return _deliveryClient.GetItemUsedIn(codename, parameters);
+        }
+
+        /// <summary>
+        /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
+        /// </summary>
+        /// <param name="codename">The codename of an asset.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
+        public IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
+        {
+            return _deliveryClient.GetAssetUsedIn(codename, parameters);
+        }
     }
 }

--- a/Kontent.Ai.Delivery.Caching/DeliveryClientCache.cs
+++ b/Kontent.Ai.Delivery.Caching/DeliveryClientCache.cs
@@ -180,7 +180,7 @@ namespace Kontent.Ai.Delivery.Caching
         /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
         /// </summary>
         /// <param name="codename">The codename of a content item.</param>
-        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <param name="parameters">A collection of query parameters for filtering.</param>
         /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
         {
@@ -191,7 +191,7 @@ namespace Kontent.Ai.Delivery.Caching
         /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
         /// </summary>
         /// <param name="codename">The codename of an asset.</param>
-        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <param name="parameters">A collection of query parameters for filtering.</param>
         /// <returns>The <see cref="IDeliveryItemsFeed{IUsedInItem}"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
         {

--- a/Kontent.Ai.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
+++ b/Kontent.Ai.Delivery.Rx.Tests/DeliveryObservableProxyTests.cs
@@ -21,6 +21,7 @@ namespace Kontent.Ai.Delivery.Rx.Tests
     public class DeliveryObservableProxyTests
     {
         private const string BEVERAGES_IDENTIFIER = "coffee_beverages_explained";
+        private const string ASSET_CODENAME = "asset_codename";
         readonly string _guid;
         readonly string _baseUrl;
         readonly MockHttpMessageHandler _mockHttp;
@@ -180,6 +181,27 @@ namespace Kontent.Ai.Delivery.Rx.Tests
             Assert.NotEmpty(languages);
             Assert.All(languages, language => Assert.NotNull(language.System));
         }
+
+        [Fact]
+        public void ItemUsedInRetrieved()
+        {
+            var observable = new DeliveryObservableProxy(GetDeliveryClient(MockItemUsedIn)).GetItemUsedInObservable(Article.Codename);
+            var parents = observable.ToEnumerable().ToList();
+
+            Assert.NotEmpty(parents);
+            Assert.All(parents, item => Assert.NotNull(item.System));
+        }
+
+        [Fact]
+        public void AssetUsedInRetrieved()
+        {
+            var observable = new DeliveryObservableProxy(GetDeliveryClient(MockAssetUsedIn)).GetAssetUsedInObservable(ASSET_CODENAME);
+            var parents = observable.ToEnumerable().ToList();
+
+            Assert.NotEmpty(parents);
+            Assert.All(parents, item => Assert.NotNull(item.System));
+        }
+
         public static IOptionsMonitor<DeliveryOptions> CreateMonitor(DeliveryOptions options)
         {
             var mock = A.Fake<IOptionsMonitor<DeliveryOptions>>();
@@ -284,6 +306,18 @@ namespace Kontent.Ai.Delivery.Rx.Tests
             _mockHttp.When($"{_baseUrl}/languages")
                 .WithQueryString("skip=1")
                 .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}languages.json")));
+        }
+
+        private void MockAssetUsedIn()
+        {
+            _mockHttp.When($"{_baseUrl}/assets/{ASSET_CODENAME}/used-in")
+                .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}used_in.json")));
+        }
+
+        private void MockItemUsedIn()
+        {
+            _mockHttp.When($"{_baseUrl}/items/{Article.Codename}/used-in")
+                .Respond("application/json", File.ReadAllText(Path.Combine(Environment.CurrentDirectory, $"Fixtures{Path.DirectorySeparatorChar}used_in.json")));
         }
 
         private static void AssertArticlePropertiesNotNull(Article item)

--- a/Kontent.Ai.Delivery.Rx.Tests/Fixtures/used_in.json
+++ b/Kontent.Ai.Delivery.Rx.Tests/Fixtures/used_in.json
@@ -1,0 +1,30 @@
+{
+  "items": [
+    {
+      "system": {
+        "id": "35778b62-e97f-42cb-833f-8a34c14e27ce",
+        "name": "rich text child",
+        "codename": "rich_text_child",
+        "language": "language1",
+        "type": "ct",
+        "collection": "default",
+        "workflow": "default",
+        "workflow_step": "published",
+        "last_modified": "2024-08-01T14:17:50.4141347Z"
+      }
+    },
+    {
+      "system": {
+        "id": "3ad63df6-a439-4a64-8193-14e999bfaaf2",
+        "name": "rich text child 2",
+        "codename": "rich_text_child_2",
+        "language": "language1",
+        "type": "ct",
+        "collection": "default",
+        "workflow": "default",
+        "workflow_step": "published",
+        "last_modified": "2024-08-01T14:17:50.4141347Z"
+      }
+    }
+  ]
+}

--- a/Kontent.Ai.Delivery.Rx.Tests/Kontent.Ai.Delivery.Rx.Tests.csproj
+++ b/Kontent.Ai.Delivery.Rx.Tests/Kontent.Ai.Delivery.Rx.Tests.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/Kontent.Ai.Delivery.Rx.Tests/Kontent.Ai.Delivery.Rx.Tests.csproj
+++ b/Kontent.Ai.Delivery.Rx.Tests/Kontent.Ai.Delivery.Rx.Tests.csproj
@@ -72,4 +72,10 @@
     <ProjectReference Include="..\Kontent.Ai.Delivery.Rx\Kontent.Ai.Delivery.Rx.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Fixtures\used_in.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Kontent.Ai.Delivery.Rx/DeliveryItemsFeedExtensions.cs
+++ b/Kontent.Ai.Delivery.Rx/DeliveryItemsFeedExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using Kontent.Ai.Delivery.Abstractions;
+
+namespace Kontent.Ai.Delivery.Rx;
+
+/// <summary>
+/// Provides extension methods for working with <see cref="IDeliveryItemsFeed{T}"/> instances in a reactive programming context.
+/// </summary>
+public static class DeliveryItemsFeedExtensions
+{
+    /// <summary>
+    /// Converts an <see cref="IDeliveryItemsFeed{T}"/> into an <see cref="IObservable{T}"/> sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of content items in the feed.</typeparam>
+    /// <param name="feed">The <see cref="IDeliveryItemsFeed{T}"/> instance to convert.</param>
+    /// <returns>
+    /// An <see cref="IObservable{T}"/> sequence that emits items retrieved from the feed.
+    /// If the feed is <c>null</c>, an empty observable sequence is returned.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Propagates any exceptions that occur during the retrieval of items from the feed.
+    /// </exception>
+    public static IObservable<T> ToObservable<T>(this IDeliveryItemsFeed<T> feed) where T : class
+    {
+        if (feed == null)
+        {
+            return Observable.Empty<T>();
+        }
+        return Observable.Create<T>(async observer =>
+        {
+            try
+            {
+                await foreach (var item in EnumerateFeed(feed))
+                {
+                    observer.OnNext(item);
+                }
+                observer.OnCompleted();
+            }
+            catch (Exception ex)
+            {
+                observer.OnError(ex);
+            }
+        });
+    }
+
+    private static async IAsyncEnumerable<T> EnumerateFeed<T>(IDeliveryItemsFeed<T> feed) where T : class
+    {
+        while (feed.HasMoreResults)
+        {
+            var batch = await feed.FetchNextBatchAsync();
+            foreach (var contentItem in batch.Items)
+            {
+                yield return contentItem;
+            }
+        }
+    }
+}

--- a/Kontent.Ai.Delivery.Rx/DeliveryObservableProxy.cs
+++ b/Kontent.Ai.Delivery.Rx/DeliveryObservableProxy.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reactive;
+using System.Threading.Tasks;
 using Kontent.Ai.Delivery.Abstractions;
 
 namespace Kontent.Ai.Delivery.Rx
@@ -104,8 +106,7 @@ namespace Kontent.Ai.Delivery.Rx
         /// <returns>The <see cref="IObservable{T}"/> that represents the content items. If no query parameters are specified, all content items are returned.</returns>
         public IObservable<T> GetItemsFeedObservable<T>(IEnumerable<IQueryParameter> parameters) where T : class
         {
-            var feed = DeliveryClient?.GetItemsFeed<T>(parameters);
-            return feed == null ? null : EnumerateFeed(feed)?.ToObservable();
+            return DeliveryClient?.GetItemsFeed<T>(parameters).ToObservable();
         }
 
         /// <summary>
@@ -127,8 +128,7 @@ namespace Kontent.Ai.Delivery.Rx
         /// <returns>The <see cref="IObservable{IUsedInItem}"/> that represents the parent content items for the specified content item. If no query parameters are specified, parents in default language are returned.</returns>
         public IObservable<IUsedInItem> GetItemUsedInObservable(string codename, IEnumerable<IQueryParameter> parameters)
         {
-            var feed = DeliveryClient?.GetItemUsedIn(codename, parameters);
-            return feed == null ? null : EnumerateFeed(feed)?.ToObservable();
+            return DeliveryClient?.GetItemUsedIn(codename, parameters).ToObservable();
         }
 
         /// <summary>
@@ -150,8 +150,7 @@ namespace Kontent.Ai.Delivery.Rx
         /// <returns>The <see cref="IObservable{IUsedInItem}"/> that represents the parent content items for the specified content item. If no query parameters are specified, parents in default language are returned.</returns>
         public IObservable<IUsedInItem> GetAssetUsedInObservable(string codename, IEnumerable<IQueryParameter> parameters)
         {
-            var feed = DeliveryClient?.GetAssetUsedIn(codename, parameters);
-            return feed == null ? null : EnumerateFeed(feed)?.ToObservable();
+            return DeliveryClient?.GetAssetUsedIn(codename, parameters).ToObservable();
         }
 
         /// <summary>
@@ -246,17 +245,6 @@ namespace Kontent.Ai.Delivery.Rx
 
         #endregion
         #region "Private methods"
-        private static IEnumerable<T> EnumerateFeed<T>(IDeliveryItemsFeed<T> feed) where T : class
-        {
-            while (feed.HasMoreResults)
-            {
-                foreach (var contentItem in feed.FetchNextBatchAsync().Result.Items)
-                {
-                    yield return contentItem;
-                }
-            }
-        }
-
         private static IObservable<T> GetObservableOfOne<T>(Func<T> responseFactory)
         {
             return Observable.Create((IObserver<T> observer) =>

--- a/Kontent.Ai.Delivery.Rx/DeliveryObservableProxy.cs
+++ b/Kontent.Ai.Delivery.Rx/DeliveryObservableProxy.cs
@@ -105,18 +105,53 @@ namespace Kontent.Ai.Delivery.Rx
         public IObservable<T> GetItemsFeedObservable<T>(IEnumerable<IQueryParameter> parameters) where T : class
         {
             var feed = DeliveryClient?.GetItemsFeed<T>(parameters);
-            return feed == null ? null : EnumerateFeed()?.ToObservable();
+            return feed == null ? null : EnumerateFeed(feed)?.ToObservable();
+        }
 
-            IEnumerable<T> EnumerateFeed()
-            {
-                while (feed.HasMoreResults)
-                {
-                    foreach (var contentItem in feed.FetchNextBatchAsync().Result.Items)
-                    {
-                        yield return contentItem;
-                    }
-                }
-            }
+        /// <summary>
+        /// Returns an observable of strongly typed parent content items for specified content item that match the optional filtering parameters. Items are enumerated in batches.
+        /// </summary>
+        /// <param name="codename">The codename of a content item.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IObservable{T}"/> that represents the parent content items for the specified content item. If no query parameters are specified, parents in default language are returned.</returns>
+        public IObservable<IUsedInItem> GetItemUsedInObservable(string codename, params IQueryParameter[] parameters)
+        {
+            return GetItemUsedInObservable(codename, (IEnumerable<IQueryParameter>)parameters);
+        }
+
+        /// <summary>
+        /// Returns an observable of strongly typed parent content items for specified content item that match the optional filtering parameters. Items are enumerated in batches.
+        /// </summary>
+        /// <param name="codename">The codename of a content item.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IObservable{IUsedInItem}"/> that represents the parent content items for the specified content item. If no query parameters are specified, parents in default language are returned.</returns>
+        public IObservable<IUsedInItem> GetItemUsedInObservable(string codename, IEnumerable<IQueryParameter> parameters)
+        {
+            var feed = DeliveryClient?.GetItemUsedIn(codename, parameters);
+            return feed == null ? null : EnumerateFeed(feed)?.ToObservable();
+        }
+
+        /// <summary>
+        /// Returns an observable of strongly typed parent content items for specified asset that match the optional filtering parameters. Items are enumerated in batches.
+        /// </summary>
+        /// <param name="codename">The codename of an asset.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IObservable{T}"/> that represents the parent content items for the specified content item. If no query parameters are specified, parents in default language are returned.</returns>
+        public IObservable<IUsedInItem> GetAssetUsedInObservable(string codename, params IQueryParameter[] parameters)
+        {
+            return GetAssetUsedInObservable(codename, (IEnumerable<IQueryParameter>)parameters);
+        }
+
+        /// <summary>
+        /// Returns an observable of strongly typed parent content items for specified asset that match the optional filtering parameters. Items are enumerated in batches.
+        /// </summary>
+        /// <param name="codename">The codename of an asset.</param>
+        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <returns>The <see cref="IObservable{IUsedInItem}"/> that represents the parent content items for the specified content item. If no query parameters are specified, parents in default language are returned.</returns>
+        public IObservable<IUsedInItem> GetAssetUsedInObservable(string codename, IEnumerable<IQueryParameter> parameters)
+        {
+            var feed = DeliveryClient?.GetAssetUsedIn(codename, parameters);
+            return feed == null ? null : EnumerateFeed(feed)?.ToObservable();
         }
 
         /// <summary>
@@ -211,6 +246,16 @@ namespace Kontent.Ai.Delivery.Rx
 
         #endregion
         #region "Private methods"
+        private static IEnumerable<T> EnumerateFeed<T>(IDeliveryItemsFeed<T> feed) where T : class
+        {
+            while (feed.HasMoreResults)
+            {
+                foreach (var contentItem in feed.FetchNextBatchAsync().Result.Items)
+                {
+                    yield return contentItem;
+                }
+            }
+        }
 
         private static IObservable<T> GetObservableOfOne<T>(Func<T> responseFactory)
         {

--- a/Kontent.Ai.Delivery.Rx/Kontent.Ai.Delivery.Rx.csproj
+++ b/Kontent.Ai.Delivery.Rx/Kontent.Ai.Delivery.Rx.csproj
@@ -25,10 +25,10 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="Microsoft.Sourcelink.Github" Version="1.1.1" PrivateAssets="All" />
-    <None Include="../README.md" Pack="true" PackagePath=""/>
-    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath=""/>
+    <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="../kai-logo-symbol-color-rgb.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kontent.Ai.Delivery.Tests/Fixtures/DeliveryClient/used_in.json
+++ b/Kontent.Ai.Delivery.Tests/Fixtures/DeliveryClient/used_in.json
@@ -1,0 +1,82 @@
+{
+  "items": [
+    {
+      "system": {
+        "id": "cf106f4e-30a4-42ef-b313-b8ea3fd3e5c5",
+        "name": "Coffee Beverages Explained",
+        "codename": "coffee_beverages_explained",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:12:58.578Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "117cdfae-52cf-4885-b271-66aef6825612",
+        "name": "Coffee processing techniques",
+        "codename": "coffee_processing_techniques",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:13:35.312Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "23f71096-fa89-4f59-a3f9-970e970944ec",
+        "name": "Donate with us",
+        "codename": "donate_with_us",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:14:07.384Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "f4b3fc05-e988-4dae-9ac1-a94aba566474",
+        "name": "On Roasts",
+        "codename": "on_roasts",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:21:11.38Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "b2fea94c-73fd-42ec-a22f-f409878de187",
+        "name": "Origins of Arabica Bourbon",
+        "codename": "origins_of_arabica_bourbon",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:21:49.151Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "3120ec15-a4a2-47ec-8ccd-c85ac8ac5ba5",
+        "name": "Which brewing fits you?",
+        "codename": "which_brewing_fits_you_",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:24:54.042Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    }
+  ]
+}

--- a/Kontent.Ai.Delivery.Tests/Fixtures/DeliveryClient/used_in_batch_1.json
+++ b/Kontent.Ai.Delivery.Tests/Fixtures/DeliveryClient/used_in_batch_1.json
@@ -1,0 +1,69 @@
+{
+  "items": [
+    {
+      "system": {
+        "id": "cf106f4e-30a4-42ef-b313-b8ea3fd3e5c5",
+        "name": "Coffee Beverages Explained",
+        "codename": "coffee_beverages_explained",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:12:58.578Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "117cdfae-52cf-4885-b271-66aef6825612",
+        "name": "Coffee processing techniques",
+        "codename": "coffee_processing_techniques",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:13:35.312Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "23f71096-fa89-4f59-a3f9-970e970944ec",
+        "name": "Donate with us",
+        "codename": "donate_with_us",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:14:07.384Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "f4b3fc05-e988-4dae-9ac1-a94aba566474",
+        "name": "On Roasts",
+        "codename": "on_roasts",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:21:11.38Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    },
+    {
+      "system": {
+        "id": "b2fea94c-73fd-42ec-a22f-f409878de187",
+        "name": "Origins of Arabica Bourbon",
+        "codename": "origins_of_arabica_bourbon",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:21:49.151Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    }
+  ]
+}

--- a/Kontent.Ai.Delivery.Tests/Fixtures/DeliveryClient/used_in_batch_2.json
+++ b/Kontent.Ai.Delivery.Tests/Fixtures/DeliveryClient/used_in_batch_2.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "system": {
+        "id": "3120ec15-a4a2-47ec-8ccd-c85ac8ac5ba5",
+        "name": "Which brewing fits you?",
+        "codename": "which_brewing_fits_you_",
+        "language": "en-US",
+        "type": "article",
+        "collection": "default",
+        "last_modified": "2019-03-27T13:24:54.042Z",
+        "workflow": "default",
+        "workflow_step": "published"
+      }
+    }
+  ]
+}

--- a/Kontent.Ai.Delivery.Tests/Kontent.Ai.Delivery.Tests.csproj
+++ b/Kontent.Ai.Delivery.Tests/Kontent.Ai.Delivery.Tests.csproj
@@ -87,6 +87,15 @@
     <None Update="Fixtures\DeliveryClient\rich_text_complex_tables.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\DeliveryClient\used_in_batch_2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\DeliveryClient\used_in_batch_1.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\DeliveryClient\used_in.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\ServiceCollectionsExtensions\deliveryOptions_as_root.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Kontent.Ai.Delivery/DeliveryClient.cs
+++ b/Kontent.Ai.Delivery/DeliveryClient.cs
@@ -372,6 +372,11 @@ namespace Kontent.Ai.Delivery
         /// <returns>The <see cref="DeliveryUsedInItems"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
         {
+            if (codename == null)
+            {
+                throw new ArgumentNullException(nameof(codename), "The codename of a content item is not specified.");
+            }
+
             ValidateUsedInParameters(parameters);
             var endpointUrl = UrlBuilder.GetItemUsedInUrl(codename, parameters);
 
@@ -386,6 +391,11 @@ namespace Kontent.Ai.Delivery
         /// <returns>The <see cref="DeliveryUsedInItems"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
         {
+            if (codename == null)
+            {
+                throw new ArgumentNullException(nameof(codename), "The codename of an asset is not specified.");
+            }
+
             ValidateUsedInParameters(parameters);
             var endpointUrl = UrlBuilder.GetAssetUsedInUrl(codename, parameters);
 

--- a/Kontent.Ai.Delivery/DeliveryClient.cs
+++ b/Kontent.Ai.Delivery/DeliveryClient.cs
@@ -368,7 +368,7 @@ namespace Kontent.Ai.Delivery
         /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
         /// </summary>
         /// <param name="codename">The codename of a content item.</param>
-        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <param name="parameters">A collection of query parameters for filtering.</param>
         /// <returns>The <see cref="DeliveryUsedInItems"/> instance that can be used to enumerate through content item parents for the specified item codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetItemUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
         {
@@ -382,7 +382,7 @@ namespace Kontent.Ai.Delivery
         /// Returns a feed that is used to traverse through strongly typed parent content items matching the optional filtering parameters.
         /// </summary>
         /// <param name="codename">The codename of an asset.</param>
-        /// <param name="parameters">A collection of query parameters, for example, for filtering or ordering.</param>
+        /// <param name="parameters">A collection of query parameters for filtering.</param>
         /// <returns>The <see cref="DeliveryUsedInItems"/> instance that can be used to enumerate through asset parents for the specified asset codename. If no query parameters are specified, default language parents are enumerated.</returns>
         public IDeliveryItemsFeed<IUsedInItem> GetAssetUsedIn(string codename, IEnumerable<IQueryParameter> parameters = null)
         {

--- a/Kontent.Ai.Delivery/UsedIn/DeliveryUsedInItems.cs
+++ b/Kontent.Ai.Delivery/UsedIn/DeliveryUsedInItems.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using Kontent.Ai.Delivery.Abstractions;
+
+namespace Kontent.Ai.Delivery.UsedIn
+{
+    /// <summary>
+    /// Represents a feed that can be used to retrieve strongly typed parent content items from Kontent.ai Delivery Used In API methods in smaller batches.
+    /// </summary>
+    internal class DeliveryUsedInItems : IDeliveryItemsFeed<IUsedInItem>
+    {
+        internal delegate Task<DeliveryUsedInResponse> GetFeedResponse(string continuationToken);
+
+        private string _continuationToken;
+        private readonly GetFeedResponse _getFeedResponseAsync;
+
+        /// <summary>
+        /// Indicates whether there are more batches to fetch.
+        /// </summary>
+        public bool HasMoreResults { get; private set; } = true;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DeliveryUsedInItems"/> class.
+        /// </summary>
+        /// <param name="getFeedResponseAsync">Function to retrieve next batch of content items.</param>
+        public DeliveryUsedInItems(GetFeedResponse getFeedResponseAsync)
+        {
+            _getFeedResponseAsync = getFeedResponseAsync;
+        }
+
+        /// <summary>
+        /// Retrieves the next feed batch if available.
+        /// </summary>
+        /// <param name="continuationToken">Optional explicit continuation token that allows you to get the next batch from a specific point in the feed.</param>
+        /// <returns>Instance of <see cref="DeliveryUsedInResponse"/> class that contains a list of strongly typed content items.</returns>
+        public async Task<IDeliveryItemsFeedResponse<IUsedInItem>> FetchNextBatchAsync(string continuationToken = null)
+        {
+            if (!HasMoreResults)
+            {
+                throw new InvalidOperationException("The feed has already been enumerated and there are no more results.");
+            }
+
+            var response = await _getFeedResponseAsync(continuationToken ?? _continuationToken);
+
+            if (!response.ApiResponse.IsSuccess)
+            {
+                return new DeliveryUsedInResponse(response.ApiResponse, null);
+            }
+            
+            _continuationToken = response.ApiResponse.ContinuationToken;
+            HasMoreResults = !string.IsNullOrEmpty(response.ApiResponse.ContinuationToken);
+
+            return response;
+        }
+    }
+}

--- a/Kontent.Ai.Delivery/UsedIn/DeliveryUsedInResponse.cs
+++ b/Kontent.Ai.Delivery/UsedIn/DeliveryUsedInResponse.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Kontent.Ai.Delivery.Abstractions;
+using Newtonsoft.Json;
+using Kontent.Ai.Delivery.SharedModels;
+
+namespace Kontent.Ai.Delivery.UsedIn;
+
+internal sealed class DeliveryUsedInResponse : AbstractResponse, IDeliveryItemsFeedResponse<IUsedInItem>
+{
+    /// <inheritdoc/>
+    public IList<IUsedInItem> Items { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeliveryUsedInResponse"/>
+    /// </summary>
+    /// <param name="response"></param>
+    /// <param name="items"></param>
+    [JsonConstructor]
+    internal DeliveryUsedInResponse(IApiResponse response, IList<IUsedInItem> items)
+        : base(response)
+    {
+        Items = items;
+    }
+
+    internal DeliveryUsedInResponse(IApiResponse response)
+        : base(response)
+    {
+    }
+}

--- a/Kontent.Ai.Delivery/UsedIn/UsedInItem.cs
+++ b/Kontent.Ai.Delivery/UsedIn/UsedInItem.cs
@@ -1,0 +1,21 @@
+﻿using Kontent.Ai.Delivery.Abstractions;
+using Newtonsoft.Json;
+
+namespace Kontent.Ai.Delivery.UsedIn;
+
+/// <inheritdoc/>
+internal sealed class UsedInItem : IUsedInItem
+{
+    /// <inheritdoc/>
+    [JsonProperty("system")]
+    public IUsedInItemSystemAttributes System { get; internal set; }
+
+    /// <summary>
+    /// Constructor used for deserialization (e.g. for caching purposes), contains no logic.
+    /// </summary>
+    [JsonConstructor]
+    public UsedInItem(IUsedInItemSystemAttributes system)
+    {
+        System = system;
+    }
+}

--- a/Kontent.Ai.Delivery/UsedIn/UsedInItemSystemAttributes.cs
+++ b/Kontent.Ai.Delivery/UsedIn/UsedInItemSystemAttributes.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Diagnostics;
+using Kontent.Ai.Delivery.Abstractions;
+using Newtonsoft.Json;
+
+namespace Kontent.Ai.Delivery.UsedIn
+{
+    /// <inheritdoc/>
+    [DebuggerDisplay("Id = {" + nameof(Id) + "}")]
+    internal sealed class UsedInItemSystemAttributes : IUsedInItemSystemAttributes
+    {
+        /// <inheritdoc/>
+        [JsonProperty("id")]
+        public string Id { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("name")]
+        public string Name { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("codename")]
+        public string Codename { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("type")]
+        public string Type { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("last_modified")]
+        public DateTime LastModified { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("language")]
+        public string Language { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("collection")]
+        public string Collection { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("workflow")]
+        public string Workflow { get; internal set; }
+
+        /// <inheritdoc/>
+        [JsonProperty("workflow_step")]
+        public string WorkflowStep { get; internal set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsedInItemSystemAttributes"/> class.
+        /// </summary>
+        [JsonConstructor]
+        public UsedInItemSystemAttributes()
+        {
+        }
+    }
+}

--- a/Kontent.Ai.Urls.Tests/DeliveryEndpointUrlBuilderTests.cs
+++ b/Kontent.Ai.Urls.Tests/DeliveryEndpointUrlBuilderTests.cs
@@ -147,4 +147,30 @@ public class DeliveryEndpointUrlBuilderTests
         var expectedLanguagesUrl = $"https://deliver.kontent.ai:443/{options.EnvironmentId}/languages";
         Assert.Equal(expectedLanguagesUrl, actualLanguagesUrl);
     }
+
+    [Fact]
+    public void GetItemUsedInUrl_ReturnsItemUsedInUrl()
+    {
+        var options = new DeliveryOptions() { EnvironmentId = Guid.NewGuid().ToString() };
+        var optionsMonitor = new FakeOptionsMonitor<DeliveryOptions>(options);
+        var deliveryEndpointUrlBuilder = new DeliveryEndpointUrlBuilder(optionsMonitor);
+
+        var actualItemUsedInUrl = deliveryEndpointUrlBuilder.GetItemUsedInUrl("item_codename", new IQueryParameter[] { });
+
+        var expectedItemUsedInUrl = $"https://deliver.kontent.ai:443/{options.EnvironmentId}/items/item_codename/used-in";
+        Assert.Equal(expectedItemUsedInUrl, actualItemUsedInUrl);
+    }
+
+    [Fact]
+    public void GetAssetUsedInUrl_ReturnsAssetUsedInUrl()
+    {
+        var options = new DeliveryOptions() { EnvironmentId = Guid.NewGuid().ToString() };
+        var optionsMonitor = new FakeOptionsMonitor<DeliveryOptions>(options);
+        var deliveryEndpointUrlBuilder = new DeliveryEndpointUrlBuilder(optionsMonitor);
+
+        var actualAssetUsedInUrl = deliveryEndpointUrlBuilder.GetAssetUsedInUrl("asset_codename", new IQueryParameter[] { });
+
+        var expectedAssetUsedInUrl = $"https://deliver.kontent.ai:443/{options.EnvironmentId}/assets/asset_codename/used-in";
+        Assert.Equal(expectedAssetUsedInUrl, actualAssetUsedInUrl);
+    }
 }

--- a/Kontent.Ai.Urls/Delivery/DeliveryEndpointUrlBuilder.cs
+++ b/Kontent.Ai.Urls/Delivery/DeliveryEndpointUrlBuilder.cs
@@ -14,6 +14,8 @@ namespace Kontent.Ai.Urls.Delivery
     {
         private const int UrlMaxLength = 65519;
         private const string UrlTemplateItem = "/items/{0}";
+        private const string UrlTemplateItemUsedIn = "/items/{0}/used-in";
+        private const string UrlTemplateAssetUsedIn= "/assets/{0}/used-in";
         private const string UrlTemplateItems = "/items";
         private const string UrlTemplateItemsFeed = "/items-feed";
         private const string UrlTemplateType = "/types/{0}";
@@ -52,7 +54,7 @@ namespace Kontent.Ai.Urls.Delivery
         /// <summary>
         /// Generates an URL for retrieving a single content item.
         /// </summary>
-        /// <param name="codename">ID of the item to be retrieved.</param>
+        /// <param name="codename">Codename of the item to be retrieved.</param>
         /// <param name="parameters">Additional filtering parameters.</param>
         /// <returns>A valid URL containing correctly formatted parameters.</returns>
         public string GetItemUrl(string codename, IEnumerable<IQueryParameter> parameters)
@@ -84,7 +86,7 @@ namespace Kontent.Ai.Urls.Delivery
         /// <summary>
         /// Generates an URL for retrieving a single content type.
         /// </summary>
-        /// <param name="codename">ID of the content type to be retrieved.</param>
+        /// <param name="codename">Codename of the content type to be retrieved.</param>
         /// <param name="parameters">Additional filtering parameters.</param>
         /// <returns>A valid URL containing correctly formatted parameters.</returns>
         public string GetTypeUrl(string codename, IEnumerable<IQueryParameter> parameters = null)
@@ -116,7 +118,7 @@ namespace Kontent.Ai.Urls.Delivery
         /// <summary>
         /// Generates an URL for retrieving a single taxonomy.
         /// </summary>
-        /// <param name="codename">ID of the content type to be retrieved.</param>
+        /// <param name="codename">Codename of the taxonomy to be retrieved.</param>
         /// <returns>A valid URL containing correctly formatted parameters.</returns>
         public string GetTaxonomyUrl(string codename)
         {
@@ -161,6 +163,28 @@ namespace Kontent.Ai.Urls.Delivery
         public string GetSyncUrl()
         {
             return GetUrl(UrlTemplateSync);
+        }
+
+        /// <summary>
+        /// Generates an URL for retrieving parents for a single content item.
+        /// </summary>
+        /// <param name="codename">Codename of the content item to be retrieved.</param>
+        /// <param name="parameters">Additional filtering parameters.</param>
+        /// <returns>A valid URL containing correctly formatted parameters.</returns>
+        public string GetItemUsedInUrl(string codename, IEnumerable<IQueryParameter> parameters)
+        {
+            return GetUrl(string.Format(UrlTemplateItemUsedIn, Uri.EscapeDataString(codename)), parameters);
+        }
+
+        /// <summary>
+        /// Generates an URL for retrieving parents for a single asset.
+        /// </summary>
+        /// <param name="codename">Codename of the asset to be retrieved.</param>
+        /// <param name="parameters">Additional filtering parameters.</param>
+        /// <returns>A valid URL containing correctly formatted parameters.</returns>
+        public string GetAssetUsedInUrl(string codename, IEnumerable<IQueryParameter> parameters)
+        {
+            return GetUrl(string.Format(UrlTemplateAssetUsedIn, Uri.EscapeDataString(codename)), parameters);
         }
 
         private string GetUrl(string path, IEnumerable<IQueryParameter> parameters)


### PR DESCRIPTION
### Motivation

Add support for new used-in delivery API feature. 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### Release date

Please do not release before the used-in is released in the production. The early access should be released in the middle of March, we will let you know. 