### PR TITLE
Add missing cache registration overloads

### DIFF
--- a/Kontent.Ai.Delivery.Caching/Extensions/DeliveryClientBuilderExtensions.cs
+++ b/Kontent.Ai.Delivery.Caching/Extensions/DeliveryClientBuilderExtensions.cs
@@ -60,6 +60,29 @@ public static class DeliveryClientBuilderExtensions
     }
 
     /// <summary>
+    /// Enables in-memory caching for API responses with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <param name="builder">The delivery client builder.</param>
+    /// <param name="configureCacheOptions">A delegate to configure the <see cref="DeliveryCacheOptions"/> with access to the <see cref="IServiceProvider"/>.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configureCacheOptions"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the cache options need to read values from other services registered in the container.
+    /// The callback is invoked on first cache-manager resolution.
+    /// </para>
+    /// <para>
+    /// Cannot be combined with hybrid cache. Calling both will use the last one configured.
+    /// </para>
+    /// </remarks>
+    public static DeliveryClientBuilder WithMemoryCache(this DeliveryClientBuilder builder, Action<IServiceProvider, DeliveryCacheOptions> configureCacheOptions)
+    {
+        ArgumentNullException.ThrowIfNull(configureCacheOptions);
+
+        return builder.ConfigureServices(services => services.AddDeliveryMemoryCache(configureCacheOptions));
+    }
+
+    /// <summary>
     /// Enables hybrid (L1 memory + L2 distributed) caching for API responses using a provided <see cref="IDistributedCache"/> instance.
     /// </summary>
     /// <param name="builder">The delivery client builder.</param>
@@ -119,6 +142,35 @@ public static class DeliveryClientBuilderExtensions
     /// </para>
     /// </remarks>
     public static DeliveryClientBuilder WithHybridCache(this DeliveryClientBuilder builder, IDistributedCache distributedCache, Action<DeliveryCacheOptions> configureCacheOptions)
+    {
+        ArgumentNullException.ThrowIfNull(distributedCache);
+        ArgumentNullException.ThrowIfNull(configureCacheOptions);
+
+        return builder.ConfigureServices(services =>
+        {
+            services.AddSingleton(distributedCache);
+            services.AddDeliveryHybridCache(configureCacheOptions);
+        });
+    }
+
+    /// <summary>
+    /// Enables hybrid (L1 memory + L2 distributed) caching with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <param name="builder">The delivery client builder.</param>
+    /// <param name="distributedCache">The distributed cache instance (e.g., Redis, SQL Server, NCache).</param>
+    /// <param name="configureCacheOptions">A delegate to configure the <see cref="DeliveryCacheOptions"/> with access to the <see cref="IServiceProvider"/>.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="distributedCache"/> or <paramref name="configureCacheOptions"/> is null.</exception>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the cache options need to read values from other services registered in the container.
+    /// The callback is invoked on first cache-manager resolution.
+    /// </para>
+    /// <para>
+    /// Cannot be combined with memory cache. Calling both will use the last one configured.
+    /// </para>
+    /// </remarks>
+    public static DeliveryClientBuilder WithHybridCache(this DeliveryClientBuilder builder, IDistributedCache distributedCache, Action<IServiceProvider, DeliveryCacheOptions> configureCacheOptions)
     {
         ArgumentNullException.ThrowIfNull(distributedCache);
         ArgumentNullException.ThrowIfNull(configureCacheOptions);

--- a/Kontent.Ai.Delivery.Caching/Extensions/DeliveryClientBuilderExtensions.cs
+++ b/Kontent.Ai.Delivery.Caching/Extensions/DeliveryClientBuilderExtensions.cs
@@ -68,8 +68,9 @@ public static class DeliveryClientBuilderExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="configureCacheOptions"/> is null.</exception>
     /// <remarks>
     /// <para>
-    /// Use this overload when the cache options need to read values from other services registered in the container.
-    /// The callback is invoked on first cache-manager resolution.
+    /// The callback receives the builder's <b>internal</b> <see cref="IServiceProvider"/> — not your application's DI container.
+    /// To make sibling services available to the callback, register them via <see cref="DeliveryClientBuilder.ConfigureServices"/>.
+    /// The callback is invoked on first cache-manager resolution from the builder's root provider.
     /// </para>
     /// <para>
     /// Cannot be combined with hybrid cache. Calling both will use the last one configured.
@@ -163,8 +164,9 @@ public static class DeliveryClientBuilderExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="distributedCache"/> or <paramref name="configureCacheOptions"/> is null.</exception>
     /// <remarks>
     /// <para>
-    /// Use this overload when the cache options need to read values from other services registered in the container.
-    /// The callback is invoked on first cache-manager resolution.
+    /// The callback receives the builder's <b>internal</b> <see cref="IServiceProvider"/> — not your application's DI container.
+    /// To make sibling services available to the callback, register them via <see cref="DeliveryClientBuilder.ConfigureServices"/>.
+    /// The callback is invoked on first cache-manager resolution from the builder's root provider.
     /// </para>
     /// <para>
     /// Cannot be combined with memory cache. Calling both will use the last one configured.

--- a/Kontent.Ai.Delivery.Caching/Extensions/ServiceCollectionExtensions.cs
+++ b/Kontent.Ai.Delivery.Caching/Extensions/ServiceCollectionExtensions.cs
@@ -120,9 +120,9 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
     /// <para>
-    /// Use this overload when the cache options need to read values from other services registered in the container,
-    /// e.g. <c>sp.GetRequiredService&lt;IOptions&lt;SiteOptions&gt;&gt;().Value</c>. The callback is invoked on first
-    /// cache-manager resolution, not at registration time.
+    /// Use this overload when the cache options need to read values from singleton-safe services registered in the
+    /// container, e.g. <c>sp.GetRequiredService&lt;IOptions&lt;SiteOptions&gt;&gt;().Value</c>. The callback is invoked on first
+    /// cache-manager resolution from the root provider, not at registration time.
     /// </para>
     /// </remarks>
     public static IServiceCollection AddDeliveryMemoryCache(
@@ -231,9 +231,9 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
     /// <para>
-    /// Use this overload when the cache options need to read values from other services registered in the container,
+    /// Use this overload when the cache options need to read values from singleton-safe services registered in the container,
     /// e.g. <c>sp.GetRequiredService&lt;IOptions&lt;SiteOptions&gt;&gt;().Value</c>. The callback is invoked the first
-    /// time the cache manager is resolved rather than at registration time; validation is deferred accordingly.
+    /// time the cache manager is resolved from the root provider rather than at registration time; validation is deferred accordingly.
     /// </para>
     /// <para>
     /// If <see cref="DeliveryCacheOptions.KeyPrefix"/> is not set, it defaults to the client name
@@ -242,6 +242,7 @@ public static class ServiceCollectionExtensions
     /// <para>
     /// <b>Avoid circular dependencies:</b> the callback must not resolve <c>IDeliveryClient</c>, <c>IDeliveryApi</c>, or any
     /// service that transitively depends on them — doing so will cause recursion when the cache manager is resolved.
+    /// The callback also must not depend on scoped/request services such as <c>IOptionsSnapshot&lt;T&gt;</c>.
     /// </para>
     /// </remarks>
     public static IServiceCollection AddDeliveryMemoryCache(
@@ -348,8 +349,8 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
     /// <para>
-    /// Use this overload when the cache options need to read values from other services registered in the container.
-    /// The callback is invoked on first cache-manager resolution, not at registration time.
+    /// Use this overload when the cache options need to read values from singleton-safe services registered in the container.
+    /// The callback is invoked on first cache-manager resolution from the root provider, not at registration time.
     /// </para>
     /// <para>
     /// <b>Prerequisites:</b> You must register an <see cref="IDistributedCache"/> implementation before calling this method.
@@ -472,8 +473,8 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection for chaining.</returns>
     /// <remarks>
     /// <para>
-    /// Use this overload when the cache options need to read values from other services registered in the container.
-    /// The callback is invoked the first time the cache manager is resolved rather than at registration time; validation is deferred accordingly.
+    /// Use this overload when the cache options need to read values from singleton-safe services registered in the container.
+    /// The callback is invoked the first time the cache manager is resolved from the root provider rather than at registration time; validation is deferred accordingly.
     /// </para>
     /// <para>
     /// <b>Prerequisites:</b> You must register an <see cref="IDistributedCache"/> implementation before calling this method.
@@ -485,6 +486,7 @@ public static class ServiceCollectionExtensions
     /// <para>
     /// <b>Avoid circular dependencies:</b> the callback must not resolve <c>IDeliveryClient</c>, <c>IDeliveryApi</c>, or any
     /// service that transitively depends on them — doing so will cause recursion when the cache manager is resolved.
+    /// The callback also must not depend on scoped/request services such as <c>IOptionsSnapshot&lt;T&gt;</c>.
     /// </para>
     /// </remarks>
     public static IServiceCollection AddDeliveryHybridCache(
@@ -538,9 +540,23 @@ public static class ServiceCollectionExtensions
         string clientName,
         Func<IServiceProvider, IDeliveryCacheManager> createCacheManager)
     {
+        RemoveExistingCacheManagerRegistration(services, clientName);
         services.AddKeyedSingleton<IDeliveryCacheManager>(clientName, (sp, _) => createCacheManager(sp));
         services.Replace(ServiceDescriptor.Singleton<IContentDependencyExtractor, ContentDependencyExtractor>());
         return services;
+    }
+
+    private static void RemoveExistingCacheManagerRegistration(IServiceCollection services, string clientName)
+    {
+        for (var i = services.Count - 1; i >= 0; i--)
+        {
+            var descriptor = services[i];
+            if (descriptor.ServiceType == typeof(IDeliveryCacheManager) &&
+                Equals(descriptor.ServiceKey, clientName))
+            {
+                services.RemoveAt(i);
+            }
+        }
     }
 
     private static void ValidateClientName(string name)

--- a/Kontent.Ai.Delivery.Caching/Extensions/ServiceCollectionExtensions.cs
+++ b/Kontent.Ai.Delivery.Caching/Extensions/ServiceCollectionExtensions.cs
@@ -113,6 +113,28 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Registers a memory cache manager for the default Delivery client with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureCacheOptions">A delegate to configure the <see cref="DeliveryCacheOptions"/> with access to the <see cref="IServiceProvider"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the cache options need to read values from other services registered in the container,
+    /// e.g. <c>sp.GetRequiredService&lt;IOptions&lt;SiteOptions&gt;&gt;().Value</c>. The callback is invoked on first
+    /// cache-manager resolution, not at registration time.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddDeliveryMemoryCache(
+        this IServiceCollection services,
+        Action<IServiceProvider, DeliveryCacheOptions> configureCacheOptions)
+    {
+        return services.AddDeliveryMemoryCache(
+            DeliveryClientNames.Default,
+            configureCacheOptions);
+    }
+
+    /// <summary>
     /// Registers a memory cache manager for a specific named Delivery client.
     /// </summary>
     /// <param name="services">The service collection.</param>
@@ -197,7 +219,44 @@ public static class ServiceCollectionExtensions
 
         var cacheOptions = CreateCacheOptions(clientName, configureCacheOptions);
 
-        return AddDeliveryMemoryCacheCore(services, clientName, cacheOptions);
+        return AddDeliveryMemoryCacheCore(services, clientName, _ => cacheOptions);
+    }
+
+    /// <summary>
+    /// Registers a memory cache manager for a specific named Delivery client with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="clientName">The name of the Delivery client to enable caching for.</param>
+    /// <param name="configureCacheOptions">A delegate to configure the <see cref="DeliveryCacheOptions"/> with access to the <see cref="IServiceProvider"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the cache options need to read values from other services registered in the container,
+    /// e.g. <c>sp.GetRequiredService&lt;IOptions&lt;SiteOptions&gt;&gt;().Value</c>. The callback is invoked the first
+    /// time the cache manager is resolved rather than at registration time; validation is deferred accordingly.
+    /// </para>
+    /// <para>
+    /// If <see cref="DeliveryCacheOptions.KeyPrefix"/> is not set, it defaults to the client name
+    /// (or empty string for the default client).
+    /// </para>
+    /// <para>
+    /// <b>Avoid circular dependencies:</b> the callback must not resolve <c>IDeliveryClient</c>, <c>IDeliveryApi</c>, or any
+    /// service that transitively depends on them — doing so will cause recursion when the cache manager is resolved.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddDeliveryMemoryCache(
+        this IServiceCollection services,
+        string clientName,
+        Action<IServiceProvider, DeliveryCacheOptions> configureCacheOptions)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ValidateClientName(clientName);
+        ArgumentNullException.ThrowIfNull(configureCacheOptions);
+
+        return AddDeliveryMemoryCacheCore(
+            services,
+            clientName,
+            sp => CreateCacheOptions(clientName, opts => configureCacheOptions(sp, opts)));
     }
 
     /// <summary>
@@ -275,6 +334,30 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddDeliveryHybridCache(
         this IServiceCollection services,
         Action<DeliveryCacheOptions> configureCacheOptions)
+    {
+        return services.AddDeliveryHybridCache(
+            DeliveryClientNames.Default,
+            configureCacheOptions);
+    }
+
+    /// <summary>
+    /// Registers a hybrid cache manager for the default Delivery client with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureCacheOptions">A delegate to configure the <see cref="DeliveryCacheOptions"/> with access to the <see cref="IServiceProvider"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the cache options need to read values from other services registered in the container.
+    /// The callback is invoked on first cache-manager resolution, not at registration time.
+    /// </para>
+    /// <para>
+    /// <b>Prerequisites:</b> You must register an <see cref="IDistributedCache"/> implementation before calling this method.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddDeliveryHybridCache(
+        this IServiceCollection services,
+        Action<IServiceProvider, DeliveryCacheOptions> configureCacheOptions)
     {
         return services.AddDeliveryHybridCache(
             DeliveryClientNames.Default,
@@ -377,17 +460,53 @@ public static class ServiceCollectionExtensions
 
         var cacheOptions = CreateCacheOptions(clientName, configureCacheOptions);
 
-        return AddDeliveryHybridCacheCore(services, clientName, cacheOptions);
+        return AddDeliveryHybridCacheCore(services, clientName, _ => cacheOptions);
+    }
+
+    /// <summary>
+    /// Registers a hybrid cache manager for a specific named Delivery client with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="clientName">The name of the Delivery client to enable caching for.</param>
+    /// <param name="configureCacheOptions">A delegate to configure the <see cref="DeliveryCacheOptions"/> with access to the <see cref="IServiceProvider"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the cache options need to read values from other services registered in the container.
+    /// The callback is invoked the first time the cache manager is resolved rather than at registration time; validation is deferred accordingly.
+    /// </para>
+    /// <para>
+    /// <b>Prerequisites:</b> You must register an <see cref="IDistributedCache"/> implementation before calling this method.
+    /// </para>
+    /// <para>
+    /// If <see cref="DeliveryCacheOptions.KeyPrefix"/> is not set, it defaults to the client name
+    /// (or empty string for the default client).
+    /// </para>
+    /// <para>
+    /// <b>Avoid circular dependencies:</b> the callback must not resolve <c>IDeliveryClient</c>, <c>IDeliveryApi</c>, or any
+    /// service that transitively depends on them — doing so will cause recursion when the cache manager is resolved.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddDeliveryHybridCache(
+        this IServiceCollection services,
+        string clientName,
+        Action<IServiceProvider, DeliveryCacheOptions> configureCacheOptions)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ValidateClientName(clientName);
+        ArgumentNullException.ThrowIfNull(configureCacheOptions);
+
+        return AddDeliveryHybridCacheCore(
+            services,
+            clientName,
+            sp => CreateCacheOptions(clientName, opts => configureCacheOptions(sp, opts)));
     }
 
     private static IServiceCollection AddDeliveryMemoryCacheCore(
         IServiceCollection services,
         string clientName,
-        DeliveryCacheOptions cacheOptions)
+        Func<IServiceProvider, DeliveryCacheOptions> cacheOptionsFactory)
     {
-        ArgumentNullException.ThrowIfNull(services);
-        ValidateClientName(clientName);
-
         // Register IMemoryCache if not already registered (shared across all clients)
         services.AddMemoryCache();
 
@@ -396,24 +515,21 @@ public static class ServiceCollectionExtensions
             clientName,
             sp => new MemoryCacheManager(
                 sp.GetRequiredService<IMemoryCache>(),
-                cacheOptions,
+                cacheOptionsFactory(sp),
                 sp.GetService<ILogger<MemoryCacheManager>>()));
     }
 
     private static IServiceCollection AddDeliveryHybridCacheCore(
         IServiceCollection services,
         string clientName,
-        DeliveryCacheOptions cacheOptions)
+        Func<IServiceProvider, DeliveryCacheOptions> cacheOptionsFactory)
     {
-        ArgumentNullException.ThrowIfNull(services);
-        ValidateClientName(clientName);
-
         return RegisterCacheManager(
             services,
             clientName,
             sp => new HybridCacheManager(
                 sp.GetRequiredService<IDistributedCache>(),
-                cacheOptions,
+                cacheOptionsFactory(sp),
                 logger: sp.GetService<ILogger<HybridCacheManager>>()));
     }
 

--- a/Kontent.Ai.Delivery.Tests/ApiApproval/PublicApiApprovalTests.CachingPublicApi_ShouldNotChangeUnexpectedly.verified.txt
+++ b/Kontent.Ai.Delivery.Tests/ApiApproval/PublicApiApprovalTests.CachingPublicApi_ShouldNotChangeUnexpectedly.verified.txt
@@ -1,0 +1,26 @@
+﻿// Kontent.Ai.Delivery
+public sealed class DeliveryClientBuilderExtensions
+    DeliveryClientBuilder WithHybridCache(DeliveryClientBuilder builder, IDistributedCache distributedCache, Nullable`1 defaultExpiration)
+    DeliveryClientBuilder WithHybridCache(DeliveryClientBuilder builder, IDistributedCache distributedCache, Action`1 configureCacheOptions)
+    DeliveryClientBuilder WithHybridCache(DeliveryClientBuilder builder, IDistributedCache distributedCache, Action`2 configureCacheOptions)
+    DeliveryClientBuilder WithMemoryCache(DeliveryClientBuilder builder, Nullable`1 defaultExpiration)
+    DeliveryClientBuilder WithMemoryCache(DeliveryClientBuilder builder, Action`1 configureCacheOptions)
+    DeliveryClientBuilder WithMemoryCache(DeliveryClientBuilder builder, Action`2 configureCacheOptions)
+
+// Kontent.Ai.Delivery
+public sealed class ServiceCollectionExtensions
+    IServiceCollection AddDeliveryCacheManager(IServiceCollection services, Func`2 createCacheManager)
+    IServiceCollection AddDeliveryCacheManager(IServiceCollection services, String clientName, Func`2 createCacheManager)
+    IServiceCollection AddDeliveryHybridCache(IServiceCollection services, Nullable`1 defaultExpiration)
+    IServiceCollection AddDeliveryHybridCache(IServiceCollection services, Action`1 configureCacheOptions)
+    IServiceCollection AddDeliveryHybridCache(IServiceCollection services, Action`2 configureCacheOptions)
+    IServiceCollection AddDeliveryHybridCache(IServiceCollection services, String clientName, String keyPrefix, Nullable`1 defaultExpiration)
+    IServiceCollection AddDeliveryHybridCache(IServiceCollection services, String clientName, Action`1 configureCacheOptions)
+    IServiceCollection AddDeliveryHybridCache(IServiceCollection services, String clientName, Action`2 configureCacheOptions)
+    IServiceCollection AddDeliveryMemoryCache(IServiceCollection services, Nullable`1 defaultExpiration)
+    IServiceCollection AddDeliveryMemoryCache(IServiceCollection services, Action`1 configureCacheOptions)
+    IServiceCollection AddDeliveryMemoryCache(IServiceCollection services, Action`2 configureCacheOptions)
+    IServiceCollection AddDeliveryMemoryCache(IServiceCollection services, String clientName, String keyPrefix, Nullable`1 defaultExpiration)
+    IServiceCollection AddDeliveryMemoryCache(IServiceCollection services, String clientName, Action`1 configureCacheOptions)
+    IServiceCollection AddDeliveryMemoryCache(IServiceCollection services, String clientName, Action`2 configureCacheOptions)
+

--- a/Kontent.Ai.Delivery.Tests/ApiApproval/PublicApiApprovalTests.PublicApi_ShouldNotChangeUnexpectedly.verified.txt
+++ b/Kontent.Ai.Delivery.Tests/ApiApproval/PublicApiApprovalTests.PublicApi_ShouldNotChangeUnexpectedly.verified.txt
@@ -15,26 +15,57 @@ public class DeliverySourceTrackingHeaderAttribute : Attribute
 
 // Kontent.Ai.Delivery
 public sealed class QueryCacheExtensions
+    IItemQuery`1 WithCacheExpiration(IItemQuery`1 query, Nullable`1 expiration)
+    IItemsQuery`1 WithCacheExpiration(IItemsQuery`1 query, Nullable`1 expiration)
+    ITypeQuery WithCacheExpiration(ITypeQuery query, Nullable`1 expiration)
+    ITypesQuery WithCacheExpiration(ITypesQuery query, Nullable`1 expiration)
+    ITaxonomyQuery WithCacheExpiration(ITaxonomyQuery query, Nullable`1 expiration)
+    ITaxonomiesQuery WithCacheExpiration(ITaxonomiesQuery query, Nullable`1 expiration)
 
 // Kontent.Ai.Delivery
 public sealed class QueryEnumerationExtensions
+    IAsyncEnumerable`1 EnumerateItemsWithStatusAsync(IItemUsedInQuery query, CancellationToken cancellationToken)
+    IAsyncEnumerable`1 EnumerateItemsWithStatusAsync(IAssetUsedInQuery query, CancellationToken cancellationToken)
+    IAsyncEnumerable`1 EnumerateItemsWithStatusAsync(IEnumerateItemsQuery`1 query, CancellationToken cancellationToken)
+    IAsyncEnumerable`1 EnumerateItemsWithStatusAsync(IDynamicEnumerateItemsQuery query, CancellationToken cancellationToken)
 
 // Kontent.Ai.Delivery
 public sealed class RichTextExtensions
+    IEnumerable`1 GetBlocks(IRichTextContent richText)
+    IEnumerable`1 GetContentItemLinks(IRichTextContent richText)
+    IEnumerable`1 GetEmbeddedContent(IRichTextContent richText)
+    IEnumerable`1 GetEmbeddedContent(IRichTextContent richText)
+    IEnumerable`1 GetEmbeddedContentOfType(IEnumerable`1 blocks)
+    IEnumerable`1 GetEmbeddedElements(IRichTextContent richText)
+    IEnumerable`1 GetInlineImages(IRichTextContent richText)
+    ValueTask`1 ParseRichTextAsync(JsonElement richTextElement, IReadOnlyDictionary`2 modularContent, CancellationToken cancellationToken)
+    ValueTask`1 ToHtmlAsync(IRichTextContent richText, IHtmlResolver resolver, CancellationToken cancellationToken)
 
 // Kontent.Ai.Delivery
 public sealed class ServiceCollectionExtensions
+    IServiceCollection AddDeliveryClient(IServiceCollection services, DeliveryOptions deliveryOptions, Action`1 configureHttpClient, Action`1 configureResilience, Action`1 configureRefit)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, Func`2 buildDeliveryOptions, Action`1 configureHttpClient, Action`1 configureResilience, Action`1 configureRefit)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, IConfiguration configuration, String configurationSectionName)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, IConfigurationSection configurationSection)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, Action`1 configureOptions)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, Action`2 configureOptions)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, Action`1 configureOptions, Action`1 configureHttpClient, Action`1 configureResilience, Action`1 configureRefit)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, Action`2 configureOptions, Action`1 configureHttpClient, Action`1 configureResilience, Action`1 configureRefit)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, String name, Action`1 configureOptions, Action`1 configureHttpClient, Action`1 configureResilience, Action`1 configureRefit)
+    IServiceCollection AddDeliveryClient(IServiceCollection services, String name, Action`2 configureOptions, Action`1 configureHttpClient, Action`1 configureResilience, Action`1 configureRefit)
 
 // Kontent.Ai.Delivery.Configuration
 public sealed class DeliveryClientBuilder
     IDeliveryClient Build()
     DeliveryClientBuilder ConfigureServices(Action`1 configure)
     DeliveryClientBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
+    DeliveryClientBuilder WithOptions(Func`2 buildDeliveryOptions)
     DeliveryClientBuilder WithTypeProvider(ITypeProvider typeProvider)
 
 // Kontent.Ai.Delivery.Configuration
 public sealed class DeliveryOptionsBuilder : IDeliveryOptionsBuilder
     DeliveryOptions Build()
+    IDeliveryOptionsBuilder CreateInstance()
     IDeliveryOptionsBuilder DisableRetryPolicy()
     IDeliveryOptionsBuilder UsePreviewApi(String previewApiKey)
     IDeliveryOptionsBuilder UseProductionApi()
@@ -49,6 +80,8 @@ public sealed class DeliveryOptionsBuilder : IDeliveryOptionsBuilder
 
 // Kontent.Ai.Delivery.Configuration
 public sealed class RefitSettingsProvider
+    JsonSerializerOptions CreateDefaultJsonSerializerOptions()
+    RefitSettings CreateDefaultSettings()
 
 // Kontent.Ai.Delivery.ContentItems
 public sealed class Asset : IAsset, IEquatable`1
@@ -90,6 +123,8 @@ public sealed class RichTextContent : IRichTextContent, IReadOnlyList`1, IReadOn
 
 // Kontent.Ai.Delivery.ContentItems.RichText.Resolution
 public sealed class DefaultResolvers
+    BlockResolver`1 HtmlElementResolver()
+    BlockResolver`1 UrlPatternResolver(IReadOnlyDictionary`2 typePatterns, String fallbackPattern)
 
 // Kontent.Ai.Delivery.ContentItems.RichText.Resolution
 public sealed class HtmlResolverBuilder : IHtmlResolverBuilder

--- a/Kontent.Ai.Delivery.Tests/ApiApproval/PublicApiApprovalTests.cs
+++ b/Kontent.Ai.Delivery.Tests/ApiApproval/PublicApiApprovalTests.cs
@@ -13,6 +13,14 @@ public class PublicApiApprovalTests
         return Verify(publicApi);
     }
 
+    [Fact]
+    public Task CachingPublicApi_ShouldNotChangeUnexpectedly()
+    {
+        var assembly = typeof(Kontent.Ai.Delivery.Caching.MemoryCacheManager).Assembly;
+        var publicApi = GetPublicApiSurface(assembly);
+        return Verify(publicApi);
+    }
+
     private static string GetPublicApiSurface(Assembly assembly)
     {
         var sb = new StringBuilder();
@@ -89,6 +97,7 @@ public class PublicApiApprovalTests
         }
 
         foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Concat(type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
             .Where(m => !m.IsSpecialName)
             .OrderBy(m => m.Name))
         {

--- a/Kontent.Ai.Delivery.Tests/Builders/Configuration/DeliveryClientBuilderTests.cs
+++ b/Kontent.Ai.Delivery.Tests/Builders/Configuration/DeliveryClientBuilderTests.cs
@@ -2,7 +2,9 @@ using System.Reflection;
 using Kontent.Ai.Delivery.Abstractions;
 using Kontent.Ai.Delivery.Configuration;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Kontent.Ai.Delivery.Tests.Builders.Configuration;
 
@@ -489,6 +491,94 @@ public class DeliveryClientBuilderTests
                     .UseProductionApi()
                     .Build())
                 .WithHybridCache(new TestDistributedCache(), (Action<DeliveryCacheOptions>)null!));
+    }
+
+    private sealed class BuilderSiblingOptions
+    {
+        public TimeSpan CacheExpiration { get; set; } = TimeSpan.FromMinutes(5);
+    }
+
+    [Fact]
+    public async Task Build_WithMemoryCache_ServiceProviderCallback_InvokesCallbackOnResolution()
+    {
+        var invokedWithExpiration = TimeSpan.Zero;
+
+        await using var client = DeliveryClientBuilder
+            .WithOptions(builder => builder
+                .WithEnvironmentId(EnvironmentId)
+                .UseProductionApi()
+                .Build())
+            .ConfigureServices(services => services.Configure<BuilderSiblingOptions>(o => o.CacheExpiration = TimeSpan.FromHours(3)))
+            .WithMemoryCache((sp, opts) =>
+            {
+                opts.DefaultExpiration = sp.GetRequiredService<IOptions<BuilderSiblingOptions>>().Value.CacheExpiration;
+                invokedWithExpiration = opts.DefaultExpiration;
+            })
+            .Build();
+
+        Assert.NotNull(client);
+        Assert.NotNull(GetCacheManager(client));
+        Assert.Equal(TimeSpan.FromHours(3), invokedWithExpiration);
+    }
+
+    [Fact]
+    public async Task Build_WithHybridCache_ServiceProviderCallback_InvokesCallbackOnResolution()
+    {
+        var distributedCache = new TestDistributedCache();
+        var invokedWithExpiration = TimeSpan.Zero;
+
+        await using var client = DeliveryClientBuilder
+            .WithOptions(builder => builder
+                .WithEnvironmentId(EnvironmentId)
+                .UseProductionApi()
+                .Build())
+            .ConfigureServices(services => services.Configure<BuilderSiblingOptions>(o => o.CacheExpiration = TimeSpan.FromHours(2)))
+            .WithHybridCache(distributedCache, (sp, opts) =>
+            {
+                opts.DefaultExpiration = sp.GetRequiredService<IOptions<BuilderSiblingOptions>>().Value.CacheExpiration;
+                invokedWithExpiration = opts.DefaultExpiration;
+            })
+            .Build();
+
+        Assert.NotNull(client);
+        Assert.NotNull(GetCacheManager(client));
+        Assert.Equal(TimeSpan.FromHours(2), invokedWithExpiration);
+    }
+
+    [Fact]
+    public void WithMemoryCache_ServiceProviderCallback_Null_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            DeliveryClientBuilder
+                .WithOptions(builder => builder
+                    .WithEnvironmentId(EnvironmentId)
+                    .UseProductionApi()
+                    .Build())
+                .WithMemoryCache((Action<IServiceProvider, DeliveryCacheOptions>)null!));
+    }
+
+    [Fact]
+    public void WithHybridCache_ServiceProviderCallback_NullDistributedCache_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            DeliveryClientBuilder
+                .WithOptions(builder => builder
+                    .WithEnvironmentId(EnvironmentId)
+                    .UseProductionApi()
+                    .Build())
+                .WithHybridCache(null!, (Action<IServiceProvider, DeliveryCacheOptions>)((_, o) => o.DefaultExpiration = TimeSpan.FromMinutes(30))));
+    }
+
+    [Fact]
+    public void WithHybridCache_ServiceProviderCallback_NullDelegate_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            DeliveryClientBuilder
+                .WithOptions(builder => builder
+                    .WithEnvironmentId(EnvironmentId)
+                    .UseProductionApi()
+                    .Build())
+                .WithHybridCache(new TestDistributedCache(), (Action<IServiceProvider, DeliveryCacheOptions>)null!));
     }
 
     // Simple test implementation of ITypeProvider

--- a/Kontent.Ai.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/Kontent.Ai.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -568,6 +568,88 @@ public class ServiceCollectionsExtensionsTests
     }
 
     [Fact]
+    public void AddDeliveryMemoryCache_AfterHybridCache_ReplacesPreviousCacheManagerRegistration()
+    {
+        _serviceCollection.AddDeliveryClient("production", o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+        _serviceCollection.AddDistributedMemoryCache();
+
+        _serviceCollection.AddDeliveryHybridCache("production");
+        _serviceCollection.AddDeliveryMemoryCache("production");
+
+        Assert.Equal(1, CountCacheManagerRegistrations("production"));
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetRequiredKeyedService<IDeliveryCacheManager>("production");
+
+        Assert.IsType<MemoryCacheManager>(cacheManager);
+    }
+
+    [Fact]
+    public void AddDeliveryHybridCache_AfterMemoryCache_ReplacesPreviousCacheManagerRegistration()
+    {
+        _serviceCollection.AddDeliveryClient("production", o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+        _serviceCollection.AddDistributedMemoryCache();
+
+        _serviceCollection.AddDeliveryMemoryCache("production");
+        _serviceCollection.AddDeliveryHybridCache("production");
+
+        Assert.Equal(1, CountCacheManagerRegistrations("production"));
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetRequiredKeyedService<IDeliveryCacheManager>("production");
+
+        Assert.IsType<HybridCacheManager>(cacheManager);
+    }
+
+    [Fact]
+    public void AddDeliveryCacheManager_AfterBuiltInCache_ReplacesPreviousCacheManagerRegistration()
+    {
+        _serviceCollection.AddDeliveryClient("production", o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+
+        _serviceCollection.AddDeliveryMemoryCache("production");
+        _serviceCollection.AddDeliveryCacheManager("production", _ => new TestCustomCacheManager());
+
+        Assert.Equal(1, CountCacheManagerRegistrations("production"));
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetRequiredKeyedService<IDeliveryCacheManager>("production");
+
+        Assert.IsType<TestCustomCacheManager>(cacheManager);
+    }
+
+    [Fact]
+    public void AddDeliveryMemoryCache_AfterCustomCacheManager_ReplacesPreviousCacheManagerRegistration()
+    {
+        _serviceCollection.AddDeliveryClient("production", o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+
+        _serviceCollection.AddDeliveryCacheManager("production", _ => new TestCustomCacheManager());
+        _serviceCollection.AddDeliveryMemoryCache("production");
+
+        Assert.Equal(1, CountCacheManagerRegistrations("production"));
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetRequiredKeyedService<IDeliveryCacheManager>("production");
+
+        Assert.IsType<MemoryCacheManager>(cacheManager);
+    }
+
+    [Fact]
     public async Task AddDeliveryMemoryCache_DefaultClient_AdvancedOverload_UsesUnprefixedNamespace()
     {
         _serviceCollection.AddDeliveryClient(o =>
@@ -1064,6 +1146,94 @@ public class ServiceCollectionsExtensionsTests
             _serviceCollection.AddDeliveryHybridCache("production", configureCacheOptions: (Action<IServiceProvider, DeliveryCacheOptions>)null!));
     }
 
+    [Fact]
+    public void AddDeliveryMemoryCache_WithServiceProviderCallback_DefersValidationUntilResolution()
+    {
+        _serviceCollection.AddDeliveryClient(o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+
+        // Zero expiration fails [PositiveTimeSpan] validation.
+        _serviceCollection.AddDeliveryMemoryCache((_, opts) => opts.DefaultExpiration = TimeSpan.Zero);
+
+        // Registration and provider construction must not throw — validation is deferred.
+        var provider = _serviceCollection.BuildServiceProvider();
+
+        Assert.Throws<ValidationException>(() =>
+            provider.GetRequiredKeyedService<IDeliveryCacheManager>("Default"));
+    }
+
+    [Fact]
+    public void AddDeliveryMemoryCache_WithInlineCallback_ValidatesEagerlyAtRegistration()
+    {
+        _serviceCollection.AddDeliveryClient(o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+
+        // Contrast with the (sp, opts) overload: the plain Action<DeliveryCacheOptions>
+        // overload validates at registration time, not at resolution.
+        Assert.Throws<ValidationException>(() =>
+            _serviceCollection.AddDeliveryMemoryCache(opts => opts.DefaultExpiration = TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void AddDeliveryHybridCache_WithServiceProviderCallback_DefersValidationUntilResolution()
+    {
+        _serviceCollection.AddDeliveryClient(o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+        _serviceCollection.AddDistributedMemoryCache();
+
+        _serviceCollection.AddDeliveryHybridCache((_, opts) => opts.DefaultExpiration = TimeSpan.Zero);
+
+        var provider = _serviceCollection.BuildServiceProvider();
+
+        Assert.Throws<ValidationException>(() =>
+            provider.GetRequiredKeyedService<IDeliveryCacheManager>("Default"));
+    }
+
+    [Fact]
+    public void AddDeliveryClient_ServiceProviderCallback_ResolvingOptionsInDelegate_ReEntersConfigureDelegate()
+    {
+        // Documents the circular-dependency guard from the XML docs: the (sp, opts) callback
+        // must not resolve IOptions<DeliveryOptions>, IDeliveryClient, or IDeliveryApi — doing
+        // so re-enters this very delegate through the options factory. Left unguarded, the MS
+        // DI runtime recurses unboundedly and stack-overflows (uncatchable by design). We use
+        // a reentrancy counter to prove the re-entry and surface a catchable exception.
+        var depth = 0;
+        _serviceCollection.AddDeliveryClient((sp, opts) =>
+        {
+            if (Interlocked.Increment(ref depth) > 1)
+            {
+                throw new InvalidOperationException("configure delegate re-entered — circular dependency via options resolution");
+            }
+
+            try
+            {
+                // Triggers the same configure delegate again via the options factory.
+                _ = sp.GetRequiredService<IOptions<DeliveryOptions>>().Value;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref depth);
+            }
+
+            opts.EnvironmentId = EnvironmentId;
+        });
+
+        var provider = _serviceCollection.BuildServiceProvider();
+
+        var ex = Assert.ThrowsAny<InvalidOperationException>(() =>
+            provider.GetRequiredService<IOptions<DeliveryOptions>>().Value);
+        Assert.Contains("re-entered", ex.Message);
+    }
+
     #endregion
 
     private sealed class TestCustomCacheManager : IDeliveryCacheManager
@@ -1082,5 +1252,12 @@ public class ServiceCollectionsExtensionsTests
 
         public Task<bool> InvalidateAsync(string[] dependencyKeys, CancellationToken cancellationToken = default)
             => Task.FromResult(true);
+    }
+
+    private int CountCacheManagerRegistrations(string clientName)
+    {
+        return _serviceCollection.Count(d =>
+            d.ServiceType == typeof(IDeliveryCacheManager) &&
+            Equals(d.ServiceKey, clientName));
     }
 }

--- a/Kontent.Ai.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/Kontent.Ai.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -44,7 +44,7 @@ public class ServiceCollectionsExtensionsTests
     public void AddDeliveryClientWithNullDeliveryOptions_ThrowsArgumentNullException() => Assert.Throws<ArgumentNullException>(() => _serviceCollection.AddDeliveryClient(deliveryOptions: null!));
 
     [Fact]
-    public void AddDeliveryClientWithNullBuildDeliveryOptions_ThrowsArgumentNullException() => Assert.Throws<ArgumentNullException>(() => _serviceCollection.AddDeliveryClient(configureOptions: null!));
+    public void AddDeliveryClientWithNullBuildDeliveryOptions_ThrowsArgumentNullException() => Assert.Throws<ArgumentNullException>(() => _serviceCollection.AddDeliveryClient(configureOptions: (Action<DeliveryOptions>)null!));
 
     [Fact]
     public void AddDeliveryClientWithOptions_AllServicesAreRegistered()
@@ -866,6 +866,202 @@ public class ServiceCollectionsExtensionsTests
         Assert.NotNull(cache2);
         Assert.NotSame(cache1, cache2);
         Assert.NotNull(memoryCache);
+    }
+
+    #endregion
+
+    #region (IServiceProvider, TOptions) Overloads
+
+    private sealed class SiblingOptions
+    {
+        public string EnvironmentIdValue { get; set; } = string.Empty;
+        public TimeSpan CacheExpiration { get; set; } = TimeSpan.FromMinutes(5);
+    }
+
+    [Fact]
+    public void AddDeliveryClient_WithServiceProviderCallback_ResolvesFromContainer()
+    {
+        _serviceCollection.Configure<SiblingOptions>(o => o.EnvironmentIdValue = EnvironmentId);
+        _serviceCollection.AddDeliveryClient((sp, opts) =>
+        {
+            opts.EnvironmentId = sp.GetRequiredService<IOptions<SiblingOptions>>().Value.EnvironmentIdValue;
+            opts.EnableResilience = false;
+        });
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var monitor = provider.GetRequiredService<IOptionsMonitor<DeliveryOptions>>();
+        Assert.Equal(EnvironmentId, monitor.CurrentValue.EnvironmentId);
+    }
+
+    [Fact]
+    public void AddDeliveryClient_NamedWithServiceProviderCallback_ResolvesFromContainer()
+    {
+        _serviceCollection.Configure<SiblingOptions>(o => o.EnvironmentIdValue = EnvironmentId);
+        _serviceCollection.AddDeliveryClient("production", (sp, opts) =>
+        {
+            opts.EnvironmentId = sp.GetRequiredService<IOptions<SiblingOptions>>().Value.EnvironmentIdValue;
+            opts.EnableResilience = false;
+        });
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var monitor = provider.GetRequiredService<IOptionsMonitor<DeliveryOptions>>();
+        Assert.Equal(EnvironmentId, monitor.Get("production").EnvironmentId);
+    }
+
+    [Fact]
+    public void AddDeliveryClient_NullServiceProviderCallback_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddDeliveryClient(configureOptions: (Action<IServiceProvider, DeliveryOptions>)null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddDeliveryClient("production", configureOptions: (Action<IServiceProvider, DeliveryOptions>)null!));
+    }
+
+    [Fact]
+    public void AddDeliveryMemoryCache_WithServiceProviderCallback_InvokesCallbackOnResolution()
+    {
+        _serviceCollection.Configure<SiblingOptions>(o => o.CacheExpiration = TimeSpan.FromHours(3));
+        _serviceCollection.AddDeliveryClient(o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+
+        var invokedWithExpiration = TimeSpan.Zero;
+        _serviceCollection.AddDeliveryMemoryCache((sp, opts) =>
+        {
+            opts.DefaultExpiration = sp.GetRequiredService<IOptions<SiblingOptions>>().Value.CacheExpiration;
+            invokedWithExpiration = opts.DefaultExpiration;
+        });
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetKeyedService<IDeliveryCacheManager>("Default");
+
+        Assert.NotNull(cacheManager);
+        Assert.IsType<MemoryCacheManager>(cacheManager);
+        Assert.Equal(TimeSpan.FromHours(3), invokedWithExpiration);
+    }
+
+    [Fact]
+    public void AddDeliveryMemoryCache_NamedWithServiceProviderCallback_InvokesCallbackOnResolution()
+    {
+        _serviceCollection.Configure<SiblingOptions>(o => o.CacheExpiration = TimeSpan.FromHours(2));
+        _serviceCollection.AddDeliveryClient("production", o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+
+        var invokedWithExpiration = TimeSpan.Zero;
+        _serviceCollection.AddDeliveryMemoryCache("production", (sp, opts) =>
+        {
+            opts.DefaultExpiration = sp.GetRequiredService<IOptions<SiblingOptions>>().Value.CacheExpiration;
+            invokedWithExpiration = opts.DefaultExpiration;
+        });
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetKeyedService<IDeliveryCacheManager>("production");
+
+        Assert.NotNull(cacheManager);
+        Assert.Equal(TimeSpan.FromHours(2), invokedWithExpiration);
+    }
+
+    [Fact]
+    public void AddDeliveryMemoryCache_WithServiceProviderCallback_DefersInvocationUntilResolution()
+    {
+        var invoked = false;
+        _serviceCollection.AddDeliveryClient(o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+        _serviceCollection.AddDeliveryMemoryCache((_, opts) =>
+        {
+            invoked = true;
+            opts.DefaultExpiration = TimeSpan.FromMinutes(10);
+        });
+
+        // Not invoked at registration time
+        Assert.False(invoked);
+
+        var provider = _serviceCollection.BuildServiceProvider();
+
+        // Not invoked just from building the provider
+        Assert.False(invoked);
+
+        _ = provider.GetRequiredKeyedService<IDeliveryCacheManager>("Default");
+
+        // Invoked on first resolution
+        Assert.True(invoked);
+    }
+
+    [Fact]
+    public void AddDeliveryMemoryCache_NullServiceProviderCallback_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddDeliveryMemoryCache(configureCacheOptions: (Action<IServiceProvider, DeliveryCacheOptions>)null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddDeliveryMemoryCache("production", configureCacheOptions: (Action<IServiceProvider, DeliveryCacheOptions>)null!));
+    }
+
+    [Fact]
+    public void AddDeliveryHybridCache_WithServiceProviderCallback_InvokesCallbackOnResolution()
+    {
+        _serviceCollection.Configure<SiblingOptions>(o => o.CacheExpiration = TimeSpan.FromHours(4));
+        _serviceCollection.AddDeliveryClient(o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+        _serviceCollection.AddDistributedMemoryCache();
+
+        var invokedWithExpiration = TimeSpan.Zero;
+        _serviceCollection.AddDeliveryHybridCache((sp, opts) =>
+        {
+            opts.DefaultExpiration = sp.GetRequiredService<IOptions<SiblingOptions>>().Value.CacheExpiration;
+            invokedWithExpiration = opts.DefaultExpiration;
+        });
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetKeyedService<IDeliveryCacheManager>("Default");
+
+        Assert.NotNull(cacheManager);
+        Assert.IsType<HybridCacheManager>(cacheManager);
+        Assert.Equal(TimeSpan.FromHours(4), invokedWithExpiration);
+    }
+
+    [Fact]
+    public void AddDeliveryHybridCache_NamedWithServiceProviderCallback_InvokesCallbackOnResolution()
+    {
+        _serviceCollection.Configure<SiblingOptions>(o => o.CacheExpiration = TimeSpan.FromHours(6));
+        _serviceCollection.AddDeliveryClient("production", o =>
+        {
+            o.EnvironmentId = EnvironmentId;
+            o.EnableResilience = false;
+        });
+        _serviceCollection.AddDistributedMemoryCache();
+
+        var invokedWithExpiration = TimeSpan.Zero;
+        _serviceCollection.AddDeliveryHybridCache("production", (sp, opts) =>
+        {
+            opts.DefaultExpiration = sp.GetRequiredService<IOptions<SiblingOptions>>().Value.CacheExpiration;
+            invokedWithExpiration = opts.DefaultExpiration;
+        });
+
+        var provider = _serviceCollection.BuildServiceProvider();
+        var cacheManager = provider.GetKeyedService<IDeliveryCacheManager>("production");
+
+        Assert.NotNull(cacheManager);
+        Assert.Equal(TimeSpan.FromHours(6), invokedWithExpiration);
+    }
+
+    [Fact]
+    public void AddDeliveryHybridCache_NullServiceProviderCallback_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddDeliveryHybridCache(configureCacheOptions: (Action<IServiceProvider, DeliveryCacheOptions>)null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            _serviceCollection.AddDeliveryHybridCache("production", configureCacheOptions: (Action<IServiceProvider, DeliveryCacheOptions>)null!));
     }
 
     #endregion

--- a/Kontent.Ai.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
+++ b/Kontent.Ai.Delivery.Tests/Extensions/ServiceCollectionsExtensionsTests.cs
@@ -101,6 +101,34 @@ public class ServiceCollectionsExtensionsTests
     }
 
     [Fact]
+    public void AddDeliveryClient_AdvancedConfigureAction_InvokesConfigureRefit()
+    {
+        var invoked = false;
+        _serviceCollection.AddDeliveryClient(
+            options => options.EnvironmentId = EnvironmentId,
+            configureHttpClient: null,
+            configureResilience: null,
+            configureRefit: _ => invoked = true);
+
+        _serviceCollection.BuildServiceProvider();
+        Assert.True(invoked);
+    }
+
+    [Fact]
+    public void AddDeliveryClient_AdvancedServiceProviderConfigureAction_InvokesConfigureRefit()
+    {
+        var invoked = false;
+        _serviceCollection.AddDeliveryClient(
+            (_, options) => options.EnvironmentId = EnvironmentId,
+            configureHttpClient: null,
+            configureResilience: null,
+            configureRefit: _ => invoked = true);
+
+        _serviceCollection.BuildServiceProvider();
+        Assert.True(invoked);
+    }
+
+    [Fact]
     public void AddDeliveryClient_ResilienceEnabled_InvokesConfigureResilience()
     {
         var invoked = false;

--- a/Kontent.Ai.Delivery/Extensions/ServiceCollectionExtensions.cs
+++ b/Kontent.Ai.Delivery/Extensions/ServiceCollectionExtensions.cs
@@ -132,6 +132,33 @@ public static partial class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Registers the Kontent.ai Delivery client with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">Action to configure the delivery options with access to the <see cref="IServiceProvider"/>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the options need to read values from other services registered in the container,
+    /// e.g. <c>sp.GetRequiredService&lt;IOptions&lt;SiteOptions&gt;&gt;().Value</c>.
+    /// </para>
+    /// <para>
+    /// <b>Avoid circular dependencies:</b> the callback must not resolve <c>IDeliveryClient</c>, <c>IDeliveryApi</c>, or any
+    /// service that transitively depends on them — doing so will recurse through options resolution when the client is built.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddDeliveryClient(
+        this IServiceCollection services,
+        Action<IServiceProvider, DeliveryOptions> configureOptions)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        return services.AddDeliveryClient(
+            DeliveryClientNames.Default,
+            configureOptions);
+    }
+
+    /// <summary>
     /// Registers the Kontent.ai Delivery client with advanced configuration options.
     /// </summary>
     /// <param name="services">The service collection.</param>
@@ -142,6 +169,27 @@ public static partial class ServiceCollectionExtensions
     public static IServiceCollection AddDeliveryClient(
         this IServiceCollection services,
         Action<DeliveryOptions> configureOptions,
+        Action<IHttpClientBuilder>? configureHttpClient,
+        Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null)
+    {
+        return services.AddDeliveryClient(
+            DeliveryClientNames.Default,
+            configureOptions,
+            configureHttpClient,
+            configureResilience);
+    }
+
+    /// <summary>
+    /// Registers the Kontent.ai Delivery client with advanced configuration options and access to the <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">Action to configure the delivery options with access to the <see cref="IServiceProvider"/>.</param>
+    /// <param name="configureHttpClient">Optional action to configure the HTTP client.</param>
+    /// <param name="configureResilience">Optional action to configure resilience policies.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDeliveryClient(
+        this IServiceCollection services,
+        Action<IServiceProvider, DeliveryOptions> configureOptions,
         Action<IHttpClientBuilder>? configureHttpClient,
         Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null)
     {
@@ -190,23 +238,66 @@ public static partial class ServiceCollectionExtensions
         Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null,
         Action<RefitSettings>? configureRefit = null)
     {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        return services.AddDeliveryClient(
+            name,
+            (_, opts) => configureOptions(opts),
+            configureHttpClient,
+            configureResilience,
+            configureRefit);
+    }
+
+    /// <summary>
+    /// Registers a named Kontent.ai Delivery client with a configuration action that can resolve services from the container.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use this overload when the options need to read values from other services registered in the container.
+    /// The callback is invoked when <see cref="Microsoft.Extensions.Options.IOptions{TOptions}"/> is first resolved,
+    /// allowing composition with sibling options such as <c>IOptions&lt;SiteOptions&gt;</c>.
+    /// </para>
+    /// <para>
+    /// See the <see cref="AddDeliveryClient(IServiceCollection, string, Action{DeliveryOptions}, Action{IHttpClientBuilder}?, Action{Polly.ResiliencePipelineBuilder{HttpResponseMessage}}?, Action{RefitSettings}?)"/>
+    /// overload for registration semantics (keyed services, factory access, options monitoring).
+    /// </para>
+    /// <para>
+    /// <b>Avoid circular dependencies:</b> the callback must not resolve <c>IDeliveryClient</c>, <c>IDeliveryApi</c>, or any
+    /// service that transitively depends on them — doing so will recurse through options resolution when the client is built.
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="name">The name of the client. Must be unique across all registrations.</param>
+    /// <param name="configureOptions">Action to configure the delivery options with access to the <see cref="IServiceProvider"/>.</param>
+    /// <param name="configureHttpClient">Optional action to configure the HTTP client.</param>
+    /// <param name="configureResilience">Optional action to configure resilience policies.</param>
+    /// <param name="configureRefit">Optional action to configure Refit settings.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a client with the same name is already registered.</exception>
+    public static IServiceCollection AddDeliveryClient(
+        this IServiceCollection services,
+        string name,
+        Action<IServiceProvider, DeliveryOptions> configureOptions,
+        Action<IHttpClientBuilder>? configureHttpClient = null,
+        Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null,
+        Action<RefitSettings>? configureRefit = null)
+    {
         ArgumentNullException.ThrowIfNull(services);
         ValidateClientName(name);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
         EnsureClientNameNotAlreadyRegistered(services, name);
 
-        // Register named options
-        services.Configure(name, configureOptions);
         services.AddOptions<DeliveryOptions>(name)
+            .Configure<IServiceProvider>((opts, sp) => configureOptions(sp, opts))
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
         // Also configure unnamed options for backward compatibility if this is the default name
         if (name == DeliveryClientNames.Default)
         {
-            services.Configure(configureOptions);
             services.AddOptions<DeliveryOptions>()
+                .Configure<IServiceProvider>((opts, sp) => configureOptions(sp, opts))
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
         }

--- a/Kontent.Ai.Delivery/Extensions/ServiceCollectionExtensions.cs
+++ b/Kontent.Ai.Delivery/Extensions/ServiceCollectionExtensions.cs
@@ -165,18 +165,21 @@ public static partial class ServiceCollectionExtensions
     /// <param name="configureOptions">Action to configure the delivery options.</param>
     /// <param name="configureHttpClient">Optional action to configure the HTTP client.</param>
     /// <param name="configureResilience">Optional action to configure resilience policies.</param>
+    /// <param name="configureRefit">Optional action to configure Refit settings.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddDeliveryClient(
         this IServiceCollection services,
         Action<DeliveryOptions> configureOptions,
         Action<IHttpClientBuilder>? configureHttpClient,
-        Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null)
+        Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null,
+        Action<RefitSettings>? configureRefit = null)
     {
         return services.AddDeliveryClient(
             DeliveryClientNames.Default,
             configureOptions,
             configureHttpClient,
-            configureResilience);
+            configureResilience,
+            configureRefit);
     }
 
     /// <summary>
@@ -186,18 +189,21 @@ public static partial class ServiceCollectionExtensions
     /// <param name="configureOptions">Action to configure the delivery options with access to the <see cref="IServiceProvider"/>.</param>
     /// <param name="configureHttpClient">Optional action to configure the HTTP client.</param>
     /// <param name="configureResilience">Optional action to configure resilience policies.</param>
+    /// <param name="configureRefit">Optional action to configure Refit settings.</param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddDeliveryClient(
         this IServiceCollection services,
         Action<IServiceProvider, DeliveryOptions> configureOptions,
         Action<IHttpClientBuilder>? configureHttpClient,
-        Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null)
+        Action<Polly.ResiliencePipelineBuilder<HttpResponseMessage>>? configureResilience = null,
+        Action<RefitSettings>? configureRefit = null)
     {
         return services.AddDeliveryClient(
             DeliveryClientNames.Default,
             configureOptions,
             configureHttpClient,
-            configureResilience);
+            configureResilience,
+            configureRefit);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ services.AddDeliveryClient(options =>
 services.AddDeliveryClient(configuration, "DeliveryOptions");
 ```
 
+#### Registration from Other DI Services
+
+Use the `IServiceProvider` overload when Delivery options need values from other registered services:
+
+```csharp
+services.Configure<SiteOptions>(configuration.GetSection("Site"));
+
+services.AddDeliveryClient((sp, options) =>
+{
+    var site = sp.GetRequiredService<IOptions<SiteOptions>>().Value;
+    options.EnvironmentId = site.EnvironmentId;
+});
+```
+
 #### Using the Builder Pattern
 
 ```csharp
@@ -1220,6 +1234,29 @@ services.AddDeliveryClient(options =>
 services.AddDeliveryHybridCache(defaultExpiration: TimeSpan.FromHours(2));
 ```
 
+#### Cache Options from Other DI Services
+
+Use the `IServiceProvider` cache overloads when cache settings need to come from other registered services:
+
+```csharp
+services.Configure<SiteOptions>(configuration.GetSection("Site"));
+
+services.AddDeliveryClient("production", (sp, options) =>
+{
+    var site = sp.GetRequiredService<IOptions<SiteOptions>>().Value;
+    options.EnvironmentId = site.EnvironmentId;
+});
+
+services.AddDeliveryMemoryCache("production", (sp, options) =>
+{
+    var site = sp.GetRequiredService<IOptions<SiteOptions>>().Value;
+    options.DefaultExpiration = site.CacheExpiration;
+    options.IsFailSafeEnabled = true;
+});
+```
+
+For callback timing and lifetime guidance, see [Configuring Cache Options from DI Services](docs/caching-guide.md#configuring-cache-options-from-di-services).
+
 Caching is transparent for cacheable query builders - once configured, cached query types are cached automatically and cache keys are built from query parameters for proper cache hits.
 
 `GetItem()` and `GetItems()` dynamic queries are intentionally excluded from SDK caching (runtime-typed results), so they always return `IsCacheHit == false`.
@@ -1267,6 +1304,8 @@ services.AddDeliveryClient("production", options => { ... });
 services.AddDeliveryCacheManager("production", sp => new CustomHybridCacheManager(
     sp.GetRequiredService<IDistributedCache>()));
 ```
+
+If you register multiple cache managers for the same client, the last registration wins.
 
 #### Detecting Cache Hits
 

--- a/docs/caching-guide.md
+++ b/docs/caching-guide.md
@@ -11,6 +11,7 @@ Caching is essential for production applications using the Kontent.ai Delivery A
 - [Configuration](#configuration)
   - [Memory Cache Setup](#memory-cache-setup)
   - [Hybrid Cache Setup](#hybrid-cache-setup)
+  - [Configuring Cache Options from DI Services](#configuring-cache-options-from-di-services)
   - [Custom Cache Manager](#custom-cache-manager)
 - [How Caching Works](#how-caching-works)
   - [Cache Keys](#cache-keys)
@@ -249,6 +250,31 @@ services.AddDeliveryClient("production", options =>
 
 services.AddDeliveryHybridCache("production", defaultExpiration: TimeSpan.FromHours(6));
 ```
+
+### Configuring Cache Options from DI Services
+
+Use the `IServiceProvider` cache overloads when cache settings need to be composed from other registered services, such as application options bound from configuration:
+
+```csharp
+services.Configure<SiteOptions>(configuration.GetSection("Site"));
+
+services.AddDeliveryClient("production", (sp, options) =>
+{
+    var site = sp.GetRequiredService<IOptions<SiteOptions>>().Value;
+    options.EnvironmentId = site.EnvironmentId;
+});
+
+services.AddDeliveryMemoryCache("production", (sp, options) =>
+{
+    var site = sp.GetRequiredService<IOptions<SiteOptions>>().Value;
+    options.DefaultExpiration = site.CacheExpiration;
+    options.IsFailSafeEnabled = true;
+});
+```
+
+Timing matters: the plain `Action<DeliveryCacheOptions>` overloads run immediately during service registration and validate cache options immediately. The `(IServiceProvider, DeliveryCacheOptions)` overloads run later, when the keyed singleton `IDeliveryCacheManager` is first resolved from the root provider, so validation is deferred to that first resolution.
+
+Because the cache manager is a singleton, resolve only singleton-safe dependencies from cache callbacks, such as `IOptions<T>`, `IOptionsMonitor<T>`, configuration, or loggers. Do not depend on scoped/request services such as `IOptionsSnapshot<T>`, `DbContext`, tenant request context, or per-request `HttpContext` state.
 
 ### Custom Cache Manager
 

--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -865,7 +865,7 @@ services.AddDeliveryMemoryCache("production", (sp, opts) =>
 });
 ```
 
-Timing: for `AddDeliveryClient`, the callback runs when `IOptions<DeliveryOptions>` is first resolved (via `OptionsBuilder.Configure<IServiceProvider>`). For the cache overloads, the callback runs the first time the keyed `IDeliveryCacheManager` is resolved. This means validation of `DeliveryCacheOptions` is deferred to resolution time for the `(sp, opts)` cache overloads, whereas the plain `Action<DeliveryCacheOptions>` cache overloads validate eagerly at registration — use the plain overload if you need registration-time failure.
+Timing: for `AddDeliveryClient`, the callback runs when `IOptions<DeliveryOptions>` is first resolved (via `OptionsBuilder.Configure<IServiceProvider>`). For the cache overloads, the callback runs the first time the keyed singleton `IDeliveryCacheManager` is resolved from the root provider. Resolve only singleton-safe dependencies from cache callbacks, such as `IOptions<T>` or `IOptionsMonitor<T>`; do not depend on scoped/request services such as `IOptionsSnapshot<T>`. Validation of `DeliveryCacheOptions` is deferred to resolution time for the `(sp, opts)` cache overloads, whereas the plain `Action<DeliveryCacheOptions>` cache overloads validate eagerly at registration — use the plain overload if you need registration-time failure.
 
 ### Core Dependencies Registration
 

--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -844,6 +844,29 @@ Cache manager resolution is keyed-only. Unkeyed `IDeliveryCacheManager` registra
 For built-in caching, use `AddDeliveryMemoryCache` / `AddDeliveryHybridCache` from the `Kontent.Ai.Delivery.Caching` package. For custom cache implementations, use `AddDeliveryCacheManager(clientName, factory)` to register per client.
 Preview cache bypass is enforced by `DeliveryClient` itself (`UsePreviewApi = true` => no cache read/write for that client), not by a cache-manager decorator.
 
+### Composing Options with `IServiceProvider`
+
+All configure-callback overloads — `AddDeliveryClient`, `AddDeliveryMemoryCache`, `AddDeliveryHybridCache`, and the fluent `WithMemoryCache` / `WithHybridCache` — have a paired overload whose callback takes `IServiceProvider` alongside the options instance. Use this shape when an option value must be read from another service registered in the container, e.g. sibling options bound via `IOptions<T>`.
+
+```csharp
+services.Configure<SiteOptions>(configuration.GetSection("Site"));
+
+services.AddDeliveryClient("production", (sp, opts) =>
+{
+    var site = sp.GetRequiredService<IOptions<SiteOptions>>().Value;
+    opts.EnvironmentId = site.EnvironmentId;
+});
+
+services.AddDeliveryMemoryCache("production", (sp, opts) =>
+{
+    var site = sp.GetRequiredService<IOptions<SiteOptions>>().Value;
+    opts.DefaultExpiration = TimeSpan.FromSeconds(site.CacheExpirationSeconds);
+    opts.IsFailSafeEnabled = true;
+});
+```
+
+Timing: for `AddDeliveryClient`, the callback runs when `IOptions<DeliveryOptions>` is first resolved (via `OptionsBuilder.Configure<IServiceProvider>`). For the cache overloads, the callback runs the first time the keyed `IDeliveryCacheManager` is resolved. This means validation of `DeliveryCacheOptions` is deferred to resolution time for the `(sp, opts)` cache overloads, whereas the plain `Action<DeliveryCacheOptions>` cache overloads validate eagerly at registration — use the plain overload if you need registration-time failure.
+
 ### Core Dependencies Registration
 
 ```csharp


### PR DESCRIPTION
### Motivation

Adds overloads exposing `IServiceProvider` for cache manager registration methods (AddDeliveryMemoryCache, AddDeliveryHybridCache...)

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
