### PR TITLE
Add empty rich text value initializer

### DIFF
--- a/Kontent.Ai.Delivery.Tests/Models/ContentTypes/Article.cs
+++ b/Kontent.Ai.Delivery.Tests/Models/ContentTypes/Article.cs
@@ -11,7 +11,7 @@ namespace Kontent.Ai.Delivery.Tests.Models.ContentTypes;
 public record Article
 {
     [JsonPropertyName("body_copy")]
-    public RichTextContent BodyCopy { get; init; } = default!;
+    public RichTextContent BodyCopy { get; init; } = RichTextContent.Empty;
 
     [JsonPropertyName("metadata__meta_description")]
     public string? MetadataMetaDescription { get; init; }

--- a/Kontent.Ai.Delivery.Tests/RichText/RichTextContentTests.cs
+++ b/Kontent.Ai.Delivery.Tests/RichText/RichTextContentTests.cs
@@ -6,6 +6,21 @@ namespace Kontent.Ai.Delivery.Tests.RichText;
 public class RichTextContentTests
 {
     [Fact]
+    public async Task Empty_IsParagraphWithLineBreak()
+    {
+        var sut = RichTextContent.Empty;
+
+        Assert.Single(sut);
+        Assert.Equal("<p><br></p>", await sut.ToHtmlAsync());
+    }
+
+    [Fact]
+    public void Empty_IsSharedSingleton()
+    {
+        Assert.Same(RichTextContent.Empty, RichTextContent.Empty);
+    }
+
+    [Fact]
     public void Count_ReturnsNumberOfBlocks()
     {
         var block = new TextNode("");

--- a/Kontent.Ai.Delivery.Tests/RichText/RichTextContentTests.cs
+++ b/Kontent.Ai.Delivery.Tests/RichText/RichTextContentTests.cs
@@ -24,8 +24,7 @@ public class RichTextContentTests
     public void Count_ReturnsNumberOfBlocks()
     {
         var block = new TextNode("");
-        var sut = new RichTextContent();
-        sut.AddRange([block]);
+        var sut = new RichTextContent([block]);
 
         Assert.Single(sut);
     }
@@ -34,8 +33,7 @@ public class RichTextContentTests
     public void Indexer_ReturnsBlockAtPosition()
     {
         var block = new TextNode("");
-        var sut = new RichTextContent();
-        sut.AddRange([block]);
+        var sut = new RichTextContent([block]);
 
         Assert.Same(block, sut[0]);
     }

--- a/Kontent.Ai.Delivery.Tests/RichText/RichTextExtensionsTests.cs
+++ b/Kontent.Ai.Delivery.Tests/RichText/RichTextExtensionsTests.cs
@@ -31,7 +31,6 @@ public class RichTextExtensionsTests
 
     private static RichTextContent CreateNestedRichTextWithEmbedded(RichTextTestModel model)
     {
-        var richText = new RichTextContent();
         var embedded = new ContentItem<RichTextTestModel>
         {
             System = new ContentItemSystemAttributes
@@ -52,8 +51,7 @@ public class RichTextExtensionsTests
             Attributes: new Dictionary<string, string>(),
             Children: [embedded]);
 
-        richText.AddRange([rootBlock]);
-        return richText;
+        return new RichTextContent([rootBlock]);
     }
 
     private sealed class RichTextTestModel

--- a/Kontent.Ai.Delivery.Tests/RichText/RichTextIntegrationTests.cs
+++ b/Kontent.Ai.Delivery.Tests/RichText/RichTextIntegrationTests.cs
@@ -985,8 +985,7 @@ public class RichTextIntegrationTests
     [Fact]
     public async Task IntegrationTest_TypeBasedResolver_DispatchesForNonContentItemNamedEmbeddedBlock()
     {
-        var richText = new RichTextContent();
-        richText.AddRange([new EmbeddedArticleBlock("Typed title")]);
+        var richText = new RichTextContent([new EmbeddedArticleBlock("Typed title")]);
 
         var resolver = new HtmlResolverBuilder()
             .WithContentResolver<Article>(content =>

--- a/Kontent.Ai.Delivery/ContentItems/Processing/RichTextParser.cs
+++ b/Kontent.Ai.Delivery/ContentItems/Processing/RichTextParser.cs
@@ -53,14 +53,7 @@ internal sealed class RichTextParser(
                 blocks.Add(block);
         }
 
-        var content = new RichTextContent
-        {
-            Links = element.Links,
-            Images = element.Images,
-            ModularContentCodenames = element.ModularContent
-        };
-        content.AddRange(blocks);
-        return content;
+        return new RichTextContent(blocks, element.Links, element.Images, element.ModularContent);
     }
 
     private async Task<IRichTextBlock?> ParseNodeAsync(

--- a/Kontent.Ai.Delivery/ContentItems/RichText/RichTextContent.cs
+++ b/Kontent.Ai.Delivery/ContentItems/RichText/RichTextContent.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Collections.Frozen;
+using Kontent.Ai.Delivery.ContentItems.RichText.Blocks;
 
 namespace Kontent.Ai.Delivery.ContentItems.RichText;
 
@@ -6,6 +8,30 @@ namespace Kontent.Ai.Delivery.ContentItems.RichText;
 public sealed class RichTextContent : IRichTextContent
 {
     private readonly List<IRichTextBlock> _blocks = [];
+
+    /// <summary>
+    /// The default Kontent.ai empty rich text value, equivalent to <c>&lt;p&gt;&lt;br&gt;&lt;/p&gt;</c>.
+    /// </summary>
+    public static RichTextContent Empty { get; } = CreateEmpty();
+
+    private static RichTextContent CreateEmpty()
+    {
+        var content = new RichTextContent();
+        content.AddRange(
+        [
+            new HtmlNode(
+                "p",
+                FrozenDictionary<string, string>.Empty,
+                [
+                    new HtmlNode(
+                        "br",
+                        FrozenDictionary<string, string>.Empty,
+                        [])
+                ])
+        ]);
+
+        return content;
+    }
 
     /// <summary>
     /// Link metadata for resolving content item links.

--- a/Kontent.Ai.Delivery/ContentItems/RichText/RichTextContent.cs
+++ b/Kontent.Ai.Delivery/ContentItems/RichText/RichTextContent.cs
@@ -7,55 +7,53 @@ namespace Kontent.Ai.Delivery.ContentItems.RichText;
 /// <inheritdoc cref="IRichTextContent" />
 public sealed class RichTextContent : IRichTextContent
 {
-    private readonly List<IRichTextBlock> _blocks = [];
+    private readonly IReadOnlyList<IRichTextBlock> _blocks;
+
+    internal RichTextContent(
+        IReadOnlyList<IRichTextBlock> blocks,
+        IReadOnlyDictionary<Guid, IContentLink>? links = null,
+        IReadOnlyDictionary<Guid, IInlineImage>? images = null,
+        IReadOnlyList<string>? modularContentCodenames = null)
+    {
+        _blocks = blocks;
+        Links = links;
+        Images = images;
+        ModularContentCodenames = modularContentCodenames;
+    }
 
     /// <summary>
     /// The default Kontent.ai empty rich text value, equivalent to <c>&lt;p&gt;&lt;br&gt;&lt;/p&gt;</c>.
     /// </summary>
-    public static RichTextContent Empty { get; } = CreateEmpty();
-
-    private static RichTextContent CreateEmpty()
-    {
-        var content = new RichTextContent();
-        content.AddRange(
-        [
-            new HtmlNode(
-                "p",
-                FrozenDictionary<string, string>.Empty,
-                [
-                    new HtmlNode(
-                        "br",
-                        FrozenDictionary<string, string>.Empty,
-                        [])
-                ])
-        ]);
-
-        return content;
-    }
+    public static RichTextContent Empty { get; } = new(
+    [
+        new HtmlNode(
+            "p",
+            FrozenDictionary<string, string>.Empty,
+            [
+                new HtmlNode(
+                    "br",
+                    FrozenDictionary<string, string>.Empty,
+                    [])
+            ])
+    ]);
 
     /// <summary>
     /// Link metadata for resolving content item links.
     /// Internal property used during HTML resolution.
     /// </summary>
-    internal IReadOnlyDictionary<Guid, IContentLink>? Links { get; set; }
+    internal IReadOnlyDictionary<Guid, IContentLink>? Links { get; }
 
     /// <summary>
     /// Image metadata for resolving inline images.
     /// Internal property used during HTML resolution.
     /// </summary>
-    internal IReadOnlyDictionary<Guid, IInlineImage>? Images { get; set; }
+    internal IReadOnlyDictionary<Guid, IInlineImage>? Images { get; }
 
     /// <summary>
     /// Modular content codenames for resolving inline content items.
     /// Internal property used during HTML resolution.
     /// </summary>
-    internal IReadOnlyList<string>? ModularContentCodenames { get; set; }
-
-    /// <summary>
-    /// Adds multiple blocks to the rich text content.
-    /// </summary>
-    /// <param name="blocks">The blocks to add.</param>
-    internal void AddRange(IEnumerable<IRichTextBlock> blocks) => _blocks.AddRange(blocks);
+    internal IReadOnlyList<string>? ModularContentCodenames { get; }
 
     /// <inheritdoc />
     public int Count => _blocks.Count;


### PR DESCRIPTION
### Motivation

adds an initializer for empty rich text element (`<p><br></p>`). this is a prerequisite for model generator changes that will generate models with default value fallbacks instead of current, "everything is nullable" behavior, to better align with the API. also introduces a slight refactor to rich text plumbing, preventing possible mutability from within the SDK and removing a leftover (and rather useless) ctor.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
