### PR TITLE
Patch vulnerable dependencies (AngleSharp CVE-2026-54570) and cap FluentAssertions below the licensed 8.x

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,9 @@
     <!-- Test dependencies -->
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.2.0" />
+    <!-- Capped below 8.0.0: FluentAssertions changed to a commercial license in 8.x.
+         The 7.x line remains Apache 2.0. Matches the range used in model-generator-net. -->
+    <PackageVersion Include="FluentAssertions" Version="[7.2.2,8.0.0)" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <!-- Build infrastructure -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- Core dependencies -->
-    <PackageVersion Include="AngleSharp" Version="1.3.0" />
+    <PackageVersion Include="AngleSharp" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
@@ -31,7 +31,7 @@
     </PackageVersion>
     <PackageVersion Include="Verify.Xunit" Version="28.3.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="NodaTime" Version="3.1.14" />


### PR DESCRIPTION
Dependency-only patch. Three lines in `Directory.Packages.props`, no source changes.

Intended for release as **19.3.1**.

| Package | Change | Reason |
|---|---|---|
| AngleSharp | 1.3.0 → 1.5.0 | CVE-2026-54570 (moderate) — **only change visible to consumers** |
| Microsoft.CodeAnalysis.CSharp.Analyzer.Testing | 1.1.2 → 1.1.4 | drops transitive System.Formats.Asn1 5.0.0, GHSA-447r-wph3-92pm (high). Test-only |
| FluentAssertions | 7.2.0 → `[7.2.2,8.0.0)` | latest still-free 7.x, plus a hard ceiling below the commercial 8.x. Test-only |

## AngleSharp CVE-2026-54570 — reachability

[GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg), CVSS 6.9. mXSS via a MathML `<annotation-xml>` HTML-integration-point bypass. Two bugs combine: a missing `HtmlTip` flag on `MathAnnotationXmlElement`, and unescaped `<` / `>` in `HtmlMarkupFormatter.WriteAttributeValue()`. Content passes a DOM-walking sanitizer looking clean, then re-parses in the browser as a live trigger.

**Only half of that is reachable here**, which is worth knowing before anyone treats this as urgent:

- **Parser side — reachable.** `RichTextParser.ConvertAsync` calls `parser.ParseDocumentAsync` (`RichTextParser.cs:33`), so the `annotation-xml` mis-parse applies.
- **Serializer side — not reachable.** The SDK never uses AngleSharp's `HtmlMarkupFormatter`. It rebuilds the parsed DOM into its own block tree (`HtmlNode` / `TextNode` / `ContentItemLink`) and serializes through `HtmlResolver`. `DefaultResolvers.BuildAttributes` runs values through `HtmlEncoder.Default.Encode`, and the default text-node resolver uses `HtmlEncoder.Create(UnicodeRanges.All)` (`HtmlResolverBuilder.cs:303-308`).

The exploit needs both halves, so the default resolution path is materially safer than the raw advisory suggests. Bumping anyway: it costs nothing, changes no API, and clears the advisory for every consumer — several of whom are otherwise carrying their own pin (e.g. kontent-ai/model-generator-net#205).

Two residual notes, neither introduced by this PR but both worth tracking separately:
- Attribute *names* and tag names are interpolated unencoded in `DefaultResolvers` (`$"{kvp.Key}=\"…\""`, `$"<{block.TagName}"`), unlike attribute values.
- The encoding guarantee is a property of the **default** resolvers. A consumer registering a custom resolver that doesn't encode, or calling `.OuterHtml` directly, is back on the vulnerable path.

## FluentAssertions ceiling

The bare `7.2.0` was resolving to exactly 7.2.0 only because nothing else in the graph asked for more. Any future transitive dependency requesting a higher version would have silently floated the build into the commercially-licensed 8.x. The range makes that impossible, and picks up 7.2.2 — the newest release still under Apache 2.0.

This mirrors the range model-generator-net already uses in its test projects.

## Verification

- `dotnet list package --vulnerable --include-transitive` — **all 10 projects clean** (was: AngleSharp moderate in 4 projects, System.Formats.Asn1 high in 1)
- Build: 0 warnings, 0 errors
- Tests: **1075 passed, 3 skipped, 0 failed** (954 + 55 + 54 + 12)
- Packed the nuspec to confirm the consumer-facing delta is exactly `AngleSharp 1.3.0 → 1.5.0`; the other two packages are `IsPackable=false` and appear nowhere in the shipped artifact

## Follow-ups (deliberately not here)

Kept out to keep this trivially reviewable and cherry-pickable:

- **Microsoft.Extensions.\* 9.0.3 → 10.0.10** — major, raises the floor for every consumer
- **Refit 10.1.6 → 14.0.1** — four majors, and 636df5f5 deliberately aligned Refit with the Management SDK
- **AngleSharp 1.6.0** exists; 1.5.0 is the minimum that fixes the CVE
- **Migrating to AwesomeAssertions** (free Apache 2.0 fork of FA 7) — 5 files, 59 call sites. Test-only, so it needs no release of its own and would retire the FluentAssertions ceiling added here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
