### PR TITLE
Harden workflow checkout and modernize action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,19 +27,20 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
+        persist-credentials: false
         fetch-depth: 0
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       # Override language selection by uncommenting this and choosing your languages
       with:
         languages: csharp
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
     - name: Install dependencies
@@ -48,4 +49,4 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -21,9 +21,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
     - name: Restore dependencies
@@ -40,7 +42,7 @@ jobs:
       run: dotnet slopwatch analyze -d . --fail-on warning
     - name: Codecov
       if: runner.os == 'Linux'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
@@ -52,9 +54,11 @@ jobs:
       PACKAGE_VERSION: 0.0.0-ci.${{ github.run_number }}
       PACK_OUTPUT: ./artifacts/pack-validation
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
     - name: Restore dependencies
@@ -119,7 +123,7 @@ jobs:
         fi
     - name: Upload pack validation artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pack-validation-artifacts
         path: |
@@ -141,9 +145,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
     - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,11 @@ jobs:
       id-token: write   # Required for OIDC token issuance
       contents: write   # Required for uploading release assets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
       - name: Extract version from tag
@@ -90,7 +92,7 @@ jobs:
             exit 1
           fi
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "NuGet packages"
           path: |


### PR DESCRIPTION
Workflow-only change. Clears the Aikido "persist Git credentials" findings and brings the pinned actions up to their current majors.

## persist-credentials

`actions/checkout` writes a credential into `.git/config` by default, leaving it readable by every later step in the job. Set `persist-credentials: false` on **all 5 checkout steps**.

Safe here — verified before changing anything:

- No workflow runs `git push`, `git commit`, `git tag` or `git config`
- No auto-commit / create-pull-request style actions
- `release.yml` passes `GH_TOKEN` explicitly to `gh release upload`, which uses the token directly and never touches the persisted git credential
- No submodules, no `ssh-key:`, no `token:` override on any checkout step

Note: Aikido flagged only `integrate.yml:144`, but this file has **three** checkout steps (lines 24, 55 and 144). All three are fixed here — fixing only the flagged line would have left the finding to reappear.

## Action versions

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-dotnet` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `codecov/codecov-action` | v5 | **v7** |
| `github/codeql-action` | v3 | **v4** |

15 `uses:` pins updated in total. These majors are Node 20 → Node 24 runtime moves requiring Actions Runner ≥ 2.327.1. Every job here runs on GitHub-hosted runners (`ubuntu-latest` / `windows-latest` / `macos-latest`), which are already past that, so no runner-side change is needed.

## Verification

- Every modified workflow parses as valid YAML
- Diff reviewed for all three indentation shapes in these files (bare `- uses:`, nested `- uses:`, and `uses:` under a `name:` with an existing `with:` block)

> Note: `release.yml` only triggers on `release: published`, so neither this PR's checks nor a merge to `master` will exercise it. Its changes are the same mechanical edit as the others, but they go unexercised until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
