### PR TITLE
align build infrastructure with the .NET monorepo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,9 +24,10 @@
     <!-- Test dependencies -->
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
-    <!-- Capped below 8.0.0: FluentAssertions changed to a commercial license in 8.x.
-         The 7.x line remains Apache 2.0. Matches the range used in model-generator-net. -->
-    <PackageVersion Include="FluentAssertions" Version="[7.2.2,8.0.0)" />
+    <!-- AwesomeAssertions is the community Apache-2.0 successor to FluentAssertions (which went
+         commercial at v8). v9 uses its own `AwesomeAssertions` namespace (not a `FluentAssertions`-namespace
+         drop-in), so test code imports `AwesomeAssertions`. -->
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,31 +4,31 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Build infrastructure -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <!-- Core dependencies -->
     <PackageVersion Include="AngleSharp" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.15" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.26" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.15" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.15" />
     <PackageVersion Include="Refit" Version="10.1.6" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
     <!-- Test dependencies -->
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <!-- AwesomeAssertions is the community Apache-2.0 successor to FluentAssertions (which went
          commercial at v8). v9 uses its own `AwesomeAssertions` namespace (not a `FluentAssertions`-namespace
          drop-in), so test code imports `AwesomeAssertions`. -->
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.19.0.132793">
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.23.0.137933">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
@@ -36,12 +36,12 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="NodaTime" Version="3.1.14" />
-    <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.24" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <!-- Benchmark dependencies -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.5.0" />

--- a/Kontent.Ai.Delivery.SourceGeneration.Tests/ContentTypeGeneratorTests.cs
+++ b/Kontent.Ai.Delivery.SourceGeneration.Tests/ContentTypeGeneratorTests.cs
@@ -1,5 +1,5 @@
 using System.Collections.Immutable;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;

--- a/Kontent.Ai.Delivery.SourceGeneration.Tests/Kontent.Ai.Delivery.SourceGeneration.Tests.csproj
+++ b/Kontent.Ai.Delivery.SourceGeneration.Tests/Kontent.Ai.Delivery.SourceGeneration.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />

--- a/Kontent.Ai.Delivery.Tests/DeliveryOptionsExtensionsTests.cs
+++ b/Kontent.Ai.Delivery.Tests/DeliveryOptionsExtensionsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Kontent.Ai.Delivery.Abstractions;
 
 namespace Kontent.Ai.Delivery.Tests;

--- a/Kontent.Ai.Delivery.Tests/Factories/DeliveryClientFactoryTests.cs
+++ b/Kontent.Ai.Delivery.Tests/Factories/DeliveryClientFactoryTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Kontent.Ai.Delivery.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Kontent.Ai.Delivery.Tests/Kontent.Ai.Delivery.Tests.csproj
+++ b/Kontent.Ai.Delivery.Tests/Kontent.Ai.Delivery.Tests.csproj
@@ -12,7 +12,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />

--- a/Kontent.Ai.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
+++ b/Kontent.Ai.Delivery.Tests/QueryParameters/IncludeTotalCountTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using Kontent.Ai.Delivery.Abstractions;
 using Kontent.Ai.Delivery.SharedModels;
 using Microsoft.Extensions.DependencyInjection;

--- a/Kontent.Ai.Delivery.Tests/RichText/RichTextExtensionsTests.cs
+++ b/Kontent.Ai.Delivery.Tests/RichText/RichTextExtensionsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Kontent.Ai.Delivery.ContentItems;
 using Kontent.Ai.Delivery.ContentItems.RichText;
 using Kontent.Ai.Delivery.ContentItems.RichText.Blocks;

--- a/docs/for-developers.md
+++ b/docs/for-developers.md
@@ -1269,7 +1269,7 @@ public async Task GetItem_WithValidCodename_ReturnsItem()
 - **RichardSzalay.MockHttp**: Mock HTTP responses
 - **Fixture files**: Reusable JSON responses from Kontent.ai
 - **xUnit**: Test framework
-- **FluentAssertions** (optional): Readable assertions
+- **AwesomeAssertions** (optional): Readable assertions
 
 ## Performance Optimizations
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "10.0.300",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
Phase 1 preparation for the monorepo consolidation. Three structural changes, no product code touched.

- **AwesomeAssertions** replaces FluentAssertions (Apache-2.0 successor; FluentAssertions went commercial at 8.x). 5 files, 59 assertions, no call site rewritten.
- **Package versions aligned** across the SDK estate so the merged `Directory.Packages.props` is a union rather than a negotiation. Notably Test.Sdk 18.4.0, coverlet 6.0.4, xunit.runner 3.0.2, MockHttp 7.0.0, SourceLink 10.0.202, Sonar 10.23.0, and the `Microsoft.Extensions.*` set onto 9.0.15.
- **SDK pinned to 10.0.300** via `global.json`. Build SDK only — target frameworks stay `net8.0`, so this is invisible to consumers.

Verified locally: 0 warnings, 1075 tests passing, coverage gate holds at 86.37%.