### PR TITLE
bump refit to a valid signature version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,12 +14,6 @@ on:
   schedule:
     - cron: '0 18 * * 1'
 
-env:
-  # Refit 10.x is author-signed with a certificate that currently reports as revoked,
-  # which fails NuGet signature verification on the Linux runner (NU3012) during restore.
-  # Disable NuGet signature verification until a re-signed Refit package is available.
-  DOTNET_NUGET_SIGNATURE_VERIFICATION: false
-
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -6,12 +6,6 @@ on:
   pull_request:
     branches: [ master, vnext, vNext ]
 
-env:
-  # Refit 10.x is author-signed with a certificate that currently reports as revoked,
-  # which fails NuGet signature verification on the Linux runners (NU3012) during restore.
-  # Disable NuGet signature verification in CI until a re-signed Refit package is available.
-  DOTNET_NUGET_SIGNATURE_VERIFICATION: false
-
 jobs:
   build:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PACK_OUTPUT: ./artifacts/release-pack
-      # Refit 10.x is author-signed with a certificate that currently reports as revoked,
-      # which fails NuGet signature verification on the Linux runner (NU3012) during restore.
-      # Disable NuGet signature verification until a re-signed Refit package is available.
-      DOTNET_NUGET_SIGNATURE_VERIFICATION: false
     permissions:
       id-token: write   # Required for OIDC token issuance
       contents: write   # Required for uploading release assets

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,10 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.15" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.15" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.15" />
-    <PackageVersion Include="Refit" Version="10.1.6" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
+    <!-- 10.2.0 is 10.1.6 re-signed with a valid certificate; the 10.1.6 signing cert was revoked
+         and fails NuGet signature verification (NU3012) on restore. See reactiveui/refit#2114. -->
+    <PackageVersion Include="Refit" Version="10.2.0" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="10.2.0" />
     <!-- Test dependencies -->
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />


### PR DESCRIPTION
### Motivation

Fixes #417 

Invalid signature on refit 10.1.6 caused pipeline errors: https://github.com/reactiveui/refit/issues/2114 Bumped the version to 10.2.0 and removed the temporary signature check bypass from workflow files. 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
